### PR TITLE
Moving repo to fuel-telemetry

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+# Since a lot of the code in this crate starts singleton processes or sets
+# singleton data, we need to unsure tests run in series.
+RUST_TEST_THREADS = "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Cargo Format
+        run: cargo fmt --all --check
+      - name: Cargo Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Cargo Test
+        run: cargo test --workspace --all-targets --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "fuel-telemetry"
+version = "0.1.0"
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuel-telemetry"
+description = "A tracing library to implement Fuel telemetry"
+
+[lib]
+name = "fuel_telemetry"
+path = "src/lib.rs"
+
+[workspace]
+members = ["fuel-telemetry-macros"]
+default-members = [".", "fuel-telemetry-macros"]
+
+[dependencies]
+fuel-telemetry-macros = { path = "./fuel-telemetry-macros" }
+
+base64 = "0.22"
+chrono = "0.4"
+dirs = "6.0"
+influxdb-line-protocol = "2.0"
+libc = "0.2"
+nix = {version = "0.29", features = ["feature", "fs", "process", "resource","signal", "time"]}
+regex = "1.5"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "default-tls"] }
+sysinfo = "0.33"
+thiserror = "2.0"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1.15", features = ["v4"] }
+
+[dev-dependencies]
+rusty-fork = "0.3"
+tempfile = "3.18"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Fuel Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,221 @@
+# Fuel Telemetry
+
+`fuel-telemetry` is a `tracing` `Layer` used to implement telemetry within our
+apps and libraries.
+
+Steps to get `fuel-telemetry` going:
+
+- Create a `TelemetryLayer` `tracing` `Layer`
+- Add the `TelemetryLayer` to a `tracing` `Subscriber`
+- Enable the `telemetry` field on `Span`s you want sent to InfluxDB
+- Use the regular `tracing` macros (e.g `info!()`, `warn!()` etc) to record `Events`
+- Start a `FileWatcher` so that telemetry files will be sent to InfluxDB
+- Start a `SystemInfoWatcher` so that system info will be recorded
+- Start generating telemetry and non-telemetry `Event`s
+
+Fortunately, most of these steps are hidden away behind convenience macros...
+
+## Using `fuel-telemetry`
+
+### Convenience Macros
+
+Within both applications and libraries, generate telemetry `Event`s using the
+following convenience macros:
+
+- `info_telemetry!()`
+- `warn_telemetry!()`
+- `error_telemetry!()`
+- `debug_telemetry!()`
+- `trace_telemetry!()`
+
+When you want to record `tracing` `Event`s but don't want them to be sent to
+InfluxDB, use the regular non-`_telemetry` suffixed `tracing` macros:
+
+- `info!()`
+- `warn!()`
+- `error!()`
+- `debug!()`
+- `trace!()`
+
+```rust
+use fuel_telemetry::prelude::*;
+
+info!("This event will be recorded");
+info_telemetry!("This event will be recorded and sent to InfluxDB");
+```
+
+For detailed examples, see `examples/*.rs`.
+
+### Already Using `forc-tracing`
+
+If you're already using `forc-tracing` within your applications and libraries,
+the quickest way to get going is to first add the `telemetry` feature to
+`forc-tracing` in your `Cargo.toml`:
+
+```toml
+[dependencies]
+forc-tracing = { version = "0.48", features = ["telemetry"] }
+```
+
+Then as above, use the convenience macros to record telemetry `Event`s:
+
+```rust
+use forc_tracing::{
+    init_tracing_subscriber, println_green, println_red, println_yellow, telemetry::*,
+};
+
+fn main() {
+    init_tracing_subscriber(Default::default());
+
+    println_red("Stop");
+    println_yellow("Slow down");
+    println_green("Go");
+
+    info_telemetry!("This event will be sent to InfluxDB");
+}
+```
+
+### Applications without Existing Tracing
+
+If you're writing an application where `fuel-telemetry` will be your only
+`tracing` `Layer` and `Subscriber`, the quickest way to get going is:
+
+```rust
+use fuel_telemetry::prelude::*;
+
+fn main() {
+    let _guard = fuel_telemetry::new_with_watchers_and_init!().unwrap();
+
+    info_telemetry!("This event will be sent to InfluxDB");
+}
+```
+
+### Applications with Existing Tracing
+
+If you're writing an application where `fuel-telemetry` will need to work along
+side other `tracing` `Layer`s or `Subscriber`s, you will need to create a
+`TelemetryLayer` by hand and then add it to your existing `Subscriber` before
+calling telemetry macros e.g:
+
+```rust
+use fuel_telemetry::prelude::*;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    // Create a `Telemetry` `Layer` where events will appear in InfluxDB
+    let (telemetry_layer, _guard) = TelemetryLayer::new_with_watchers!().unwrap();
+
+    // Create a stdout `Layer` where events will appear on `stdout`
+    let stdout_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stdout);
+
+    // Create a `Subscriber` and combine these two `Layers`
+    let subscriber = tracing_subscriber::registry()
+        .with(telemetry_layer)
+        .with(stdout_layer);
+
+    // Set our subscriber as the default global subscriber
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    info!("This event will be sent to stdout");
+    info_telemetry!("This event will be sent to InfluxDB");
+}
+```
+
+### Within Libraries
+
+**Warning: libraries should not be setting the global default subscriber as it
+will clobber any set by consumer applications. As such, `fuel-telemetry` will
+prevent your code from compiling if you try to set the global default subscriber
+via the constructor macro `new_with_watchers_and_init!()`.**
+
+As above, to get started recording telemetry within your libraries, use the
+convenience macros to record telemetry `Event`s:
+```rust
+use fuel_telemetry::prelude::*;
+
+info!("This event will be recorded");
+info_telemetry!("This event will be recorded and sent to InfluxDB");
+```
+
+## Manually Enabling Telemetry
+
+The easiest way to record telemetry events is to just use the above convenience
+macros. Howevery, if you want more control by taking advantage of `tracing`'s
+function attributes and `Span` heirarchies, read on...
+
+Each `tracing` `Event` has telemetry `enabled` or `disabled` based on the
+current `Span`'s setting (if one exists). By default, the root `Span` is
+disabled.
+
+There are 2 ways to set the `telemetry` field:
+
+1. On a `Span` itself e.g `span!(Level::ERROR, "span_name", telemetry=true)`
+1. Via function attributes e.g `#[tracing::instrument(fields(telemetry=true))]`
+
+Given that `tracing` `Span`s are hierarchical, if a function does not have a
+`tracing` attribute, or it does have one but the `telemetry` field is not set, we
+fall back by climbing the hierarchy until we explicitly find one set. In the end
+if no `Span` is found, we default to `telemetry=false`.
+
+**Warning: Be careful when using function attributes to enable telemetry as
+every function call invocation (along with its parameter names and values)
+will be a recorded as separate `Event`s and subsequently sent to InfluxDB...**
+
+* If used within a hot path, lots of data will be generated and sent over the
+wire. Times this by the amount of installs across the entire userbase, and
+you'll see that it could be an overwhelming amount of data and it's eventual
+cost.
+
+* PII (Personally Identifiable Information) and other sensitive information
+  (think private keys and passwords) could make its way to InfluxDB by accident.
+  If your functions have any PII (including Public Keys or even hashes of unique
+  data etc), use the `skip()` function attribute i.e:
+
+  `#[tracing::instrument(skip(secret_key, password))]`
+
+## Debugging Telemetry
+
+### Inspecting Telemetry Files
+
+Telemetry files on disk are stored Base64 encoded. To peek into them:
+
+```sh
+cat ~/.fuelup/tmp/*.telemetry.* | while read line; do echo "$line" | base64 -d; echo; done
+```
+
+### Manually Aging Out Telemetry Files
+
+As `FileWatcher` only submits files to InfluxDB that are over an hour old by
+default, we can force files to age out early so they are instantly submitted
+on directory poll:
+
+```sh
+for f in ~/.fuelup/tmp/*.telemetry.*; do mv "$f" "$f.old"; done
+touch -t 202501010101 ~/.fuelup/tmp/*
+```
+
+### Overriding InfluxDB's Endpoint
+
+Use the `INFLUXDB_URL` environment variable to point to a different InfluxDB
+endpoint. This can be combined with running a local InfluxDB container:
+
+```sh
+docker compose up influxdb2
+export INFLUXDB_URL=http://localhost:8086
+```
+
+The InfluxDB connection settings can be further configured using the following
+environment variables:
+
+- `INFLUXDB_TOKEN`
+- `INFLUXDB_ORG`
+- `INFLUXDB_BUCKET`
+
+See InfluxDB's documentation for [Using Docker
+Compose](https://docs.influxdata.com/influxdb/v2/install/use-docker-compose/)
+for more info on getting InfluxDB running locally.
+
+### Architectural Design
+
+To get an overview of how `fuel-telemetry` works, the Architectural Design can
+be found in `docs/architecture.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,141 @@
+# `fuel-telemetry` Architecture Design
+
+This document describes the `fuel-telemetry` architectural design using the [C4 Model](https://c4model.com/).
+
+### Level 1: Context Diagram
+
+The Context Diagram provides a high-level overview of `fuel-telemetry`, its users, and its interactions with external systems.
+
+```mermaid
+graph TD
+  subgraph Users
+    A[Smart Contract Developers]
+    B[Frontend Developers]
+    C[Node Operators]
+  end
+
+  subgraph User-facing External Systems
+    D[Rust Binaries]
+    E[Non-Rust Binaries]
+  end
+
+  subgraph fuel-telemetry
+    F[fuel_telemetry API]
+    G[FileWatcher]
+    H[ProcessWatcher]
+    I[SystemInfoWatcher]
+  end
+
+  subgraph External Systems
+    J[InfluxDB API]
+  end
+
+  A -->|Uses| D
+  A -->|Uses| E
+  B -->|Uses| D
+  B -->|Uses| E
+  C -->|Uses| D
+  C -->|Uses| E
+
+  D -->|Creates tracing subscriber| F
+
+  F -->|"Starts FileWatcher<br />automatically via<br />telemetry_init()"| G
+  E -->|"Writes telemetry files<br />via language libraries<br />then starts FileWatcher<br />via fuel-telemetry binary"| G
+  D -->|"Starts FileWatcher<br />manually via<br />start()"| G
+
+  G -->|Connects to| J
+  G -->|Starts ProcessWatcher| H
+  G -->|Starts SystemInfoWatcher| I
+```
+
+### Level 2: Container Diagram
+
+The Container Diagram shows the main containers of `fuel-telemetry` and their interactions.
+
+```mermaid
+graph TD
+  subgraph fuel-telemetry
+    A[Externally created<br />telemetry files]
+    B[fuel_telemetry API]
+    C[FileWatcher]
+    D[ProcessWatcher]
+    E[SystemInfoWatcher]
+  end
+
+    F[Sysinfo API]
+
+  subgraph External Systems
+    G[InfluxDB API]
+  end
+
+  B -->|"Writes telemetry files via<br />macros eg debug!()"| C
+  A -->|"Are ingested and<br />cleaned up by"| C
+
+  C -->|Sends Metrics| G
+  C -->|Gathers process<br />telemetry via| D
+  C -->|Gathers system<br />telemetry via| E
+  D --> F
+  E --> F
+```
+
+### Level 3: Component Diagram
+
+The Component Diagram breaks down each container into its individual components and shows their interactions.
+
+```mermaid
+graph TD
+  subgraph fuel-telemetry
+    A[fuel_telemetry API]
+    B[FileWatcher]
+    C[ProcessWatcher]
+    D[SystemInfoWatcher]
+  end
+
+  subgraph External Systems
+    E[InfluxDB API]
+    F[Disk]
+    G[Sysinfo API]
+  end
+
+  A -->|Writes telemetry files| F
+  B -->|Ingests and cleans up| F
+  C -->|Writes telemetry files| F
+  D -->|Writes telemetry files| F
+
+  B -->|Sends Metrics| E
+  B -->|Starts| C
+  B -->|Starts| D
+  C -->|Gathers process telemetry| G
+  D -->|Gathers system telemetry| G
+```
+
+### Level 4: Code Diagram
+
+The Code Diagram provides a detailed view of the code structure within each component. This level is typically represented using class diagrams, package diagrams, or similar.
+
+```mermaid
+classDiagram
+  class TelemetryLayer {
+   telemetry_init()
+   ::new()
+   ::new_global_default()
+   ::new_global_default_with_filewatcher()
+   .set_global_default()
+  }
+
+  class FileWatcher {
+   ::new()
+   .start()
+  }
+
+  class ProcessWatcher {
+   ::new()
+   .start()
+  }
+
+  class SystemInfoWatcher {
+   ::new()
+   .start()
+  }
+
+```

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,30 @@
+use fuel_telemetry::prelude::*;
+
+fn main() {
+    // The following line:
+    // - starts a `FileWatcher` and `SystemInfoWatcher`
+    // - creates a `TelemetryLayer` and its drop guard
+    // - sets the global default `Subscriber` to the `TelemetryLayer`
+    let _guard = fuel_telemetry::new_with_watchers_and_init!().unwrap();
+
+    get_public_data(42);
+    get_private_data(99);
+}
+
+fn get_public_data(seed: u64) {
+    let start = std::time::Instant::now();
+    // <process that takes a while>
+    let duration = start.elapsed().as_secs_f64();
+
+    // The following `Event` will be sent to InfluxDB
+    info_telemetry!(seed, duration);
+}
+
+fn get_private_data(seed: u64) {
+    let start = std::time::Instant::now();
+    // <process that takes a while>
+    let duration = start.elapsed().as_secs_f64();
+
+    // The following `Event` will NOT be sent to InfluxDB
+    info!(seed, duration);
+}

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,0 +1,44 @@
+use fuel_telemetry::prelude::*;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    // The following line:
+    // - starts a `FileWatcher` and `SystemInfoWatcher`
+    // - creates a `TelemetryLayer` and its drop guard
+    let (telemetry_layer, _guard) = fuel_telemetry::new_with_watchers!().unwrap();
+
+    // Create a stdout `Layer`
+    let stdout_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stdout);
+
+    // Create a `Subscriber` and combine these two `Layers`
+    let subscriber = tracing_subscriber::registry()
+        .with(telemetry_layer)
+        .with(stdout_layer);
+
+    // Set our subscriber as the global default `Subscriber`, which contains the
+    // above two `tracing` `Layers`:
+    // - `TelemetryLayer` events will appear within InfluxDB
+    // - `stdout_layer` will print events to stdout
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    get_public_data(42);
+    get_private_data(99);
+}
+
+fn get_public_data(seed: u64) {
+    let start = std::time::Instant::now();
+    // <process that takes a while>
+    let duration = start.elapsed().as_secs_f64();
+
+    // The following `Event` will sent to InfluxDB
+    info_telemetry!(seed, duration);
+}
+
+fn get_private_data(seed: u64) {
+    let start = std::time::Instant::now();
+    // <process that takes a while>
+    let duration = start.elapsed().as_secs_f64();
+
+    // The following `Event` will be printed but NOT sent to InfluxDB
+    info!(seed, duration);
+}

--- a/examples/verbose.rs
+++ b/examples/verbose.rs
@@ -1,0 +1,53 @@
+use fuel_telemetry::{file_watcher, prelude::*, systeminfo_watcher};
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    // Warning: We need to create the `FileWatcher` and `SystemInfoWatcher`
+    // before the `TelemetryLayer` as there is a race condition between the
+    // thread runtime of `tracing` and the tokio runtime of `Reqwest`. Swapping
+    // order of the two could lead to possible deadlocks.
+
+    // Create a `FileWatcher` to submit telemetry to InfluxDB
+    let mut file_watcher = file_watcher::FileWatcher::new();
+
+    // Start the `FileWatcher`
+    file_watcher.start().unwrap_or_else(|e| {
+        panic!("FileWatcher start failed: {e:?}");
+    });
+
+    // Create a `SystemInfoWatcher` to record system info
+    let mut systeminfo_watcher = systeminfo_watcher::SystemInfoWatcher::new();
+
+    // Start the `SystemInfoWatcher`
+    systeminfo_watcher.start().unwrap_or_else(|e| {
+        panic!("SystemInfoWatcher start failed: {e:?}");
+    });
+
+    // Create a `TelemetryLayer` and its drop guard
+    let (telemetry_layer, _guard) = fuel_telemetry::new!().unwrap();
+
+    // Set the global default `Subscriber` to the `TelemetryLayer`
+    let subscriber = tracing_subscriber::registry().with(telemetry_layer);
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    get_public_data(42);
+    get_private_data(99);
+}
+
+fn get_public_data(seed: u64) {
+    let start = std::time::Instant::now();
+    // <process that takes a while>
+    let duration = start.elapsed().as_secs_f64();
+
+    // The following `Event` will be sent to InfluxDB
+    info_telemetry!(seed, duration);
+}
+
+fn get_private_data(seed: u64) {
+    let start = std::time::Instant::now();
+    // <process that takes a while>
+    let duration = start.elapsed().as_secs_f64();
+
+    // The following `Event` will NOT be sent to InfluxDB
+    info!(seed, duration);
+}

--- a/fuel-telemetry-macros/Cargo.toml
+++ b/fuel-telemetry-macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fuel-telemetry-macros"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "2.0"

--- a/fuel-telemetry-macros/src/lib.rs
+++ b/fuel-telemetry-macros/src/lib.rs
@@ -1,0 +1,226 @@
+use quote::quote;
+
+extern crate proc_macro;
+
+const LOG_FILTER: &str = "RUST_LOG";
+
+// Sets environment variables from the cargo target's perspective
+//
+// These values need to come from the cargo target which can only be found
+// during macro expansion. Calling `env!('CARGO_PKG_NAME')` within
+// `telemetry_layer.rs` will be incorrect as the macro will have already
+// expanded leading to the constant value "fuel-telemetry" for all targets
+fn set_env_vars() -> proc_macro2::TokenStream {
+    quote! {
+        if std::env::var("TELEMETRY_PKG_NAME").is_err() {
+            std::env::set_var("TELEMETRY_PKG_NAME", fuel_telemetry::get_process_name());
+        }
+
+        if std::env::var("TELEMETRY_PKG_VERSION").is_err() {
+            std::env::set_var("TELEMETRY_PKG_VERSION", env!("CARGO_PKG_VERSION"));
+        }
+    }
+}
+
+// Starts the `FileWatcher` and `SystemInfoWatcher` daemon
+//
+// Warning: We need to create the `FileWatcher` and `SystemInfoWatcher`
+// before the `TelemetryLayer` as there is a race condition in the
+// thread runtime of `tracing` and the tokio runtime of `Reqwest`.
+// Swapping order of the two could lead to possible deadlocks.
+//
+// If the watchers fail to start, we silently ignore the errors as
+// telemetry should not impede the program from running.
+fn start_watchers() -> proc_macro2::TokenStream {
+    quote! {
+        // In the following, we need to log all errors but as there is no
+        // `tracing` `Subscriber` running yet, we need to fall back to appending
+        // plain text to the log file instead
+        //
+        // Another thing to note is that as this is the original process, we
+        // only exit on `Fatal` errors, meaning that we have since forked and
+        // have become a child process so can safely fatally exit
+
+        // Start the `ProcessWatcher`
+        match fuel_telemetry::process_watcher::ProcessWatcher::new() {
+            Ok(mut process_watcher) => {
+                if let Err(err) = process_watcher.start() {
+                    let _ = fuel_telemetry::process_watcher::ProcessWatcher::log_error(&format!("Failed to start `ProcessWatcher`: {:?}", err));
+
+                    if err.is_fatal() {
+                        std::process::exit(1);
+                    }
+                }
+            }
+            Err(err) => {
+                let _ = fuel_telemetry::process_watcher::ProcessWatcher::log_error(&format!("Failed to create `ProcessWatcher`: {:?}", err));
+                // Don't exit as this is the original process and we need to continue
+            }
+        }
+
+        // Start the `FileWatcher`
+        let mut file_watcher = fuel_telemetry::file_watcher::FileWatcher::new();
+        if let Err(err) = file_watcher.start() {
+            let _ = fuel_telemetry::file_watcher::FileWatcher::log_error(&format!("Failed to start `FileWatcher`: {:?}", err));
+
+            if err.is_fatal() {
+                std::process::exit(1);
+            }
+        }
+
+        // Start the `SystemInfoWatcher`
+        let mut systeminfo_watcher = fuel_telemetry::systeminfo_watcher::SystemInfoWatcher::new();
+        if let Err(err) = systeminfo_watcher.start() {
+            let _ = fuel_telemetry::systeminfo_watcher::SystemInfoWatcher::log_error(&format!("Failed to start `SystemInfoWatcher`: {:?}", err));
+
+            if err.is_fatal() {
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+/// Create a new `TelemetryLayer`.
+///
+/// This `tracing` `Layer` is to be used along with the `tracing` crate, and
+/// composes with other `Layer`s to create a `Subscriber`.
+///
+/// Returns a `TelemetryLayer` and a drop guard. Here, the drop guard will flush
+/// any remaining telemetry to the disk.
+///
+/// Warning: this function does not create a `FileWatcher` and
+/// `SystemInfoWatcher`, and so although telemetry files will be written to
+/// disk, they will not be sent to InfluxDB. If in doubt, prefer using
+/// `new_with_watchers!()` or `new_with_watchers_and_init!()` over `new!()`.
+///
+/// ```text
+/// use fuel_telemetry::TelemetryLayer;
+///
+/// let (telemetry_layer, _guard) = fuel_telemetry::new!()?;
+/// tracing_subscriber::registry().with(telemetry_layer).init();
+///
+/// info_telemetry!("This event will be sent to InfluxBD");
+/// ```
+#[proc_macro]
+pub fn new(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let env_vars = set_env_vars();
+
+    quote! {
+        {
+            #env_vars
+
+            fuel_telemetry::TelemetryLayer::__new().and_then(|(layer, guard)| {
+                use fuel_telemetry::__reexport_EnvFilter;
+                use fuel_telemetry::__reexport_Layer;
+
+                std::env::var_os(#LOG_FILTER)
+                    .map_or_else(
+                        || Ok(__reexport_EnvFilter::new("info")),
+                        |_| __reexport_EnvFilter::try_from_default_env()
+                            .map_err(|e| fuel_telemetry::TelemetryError::InvalidEnvFilter(e.to_string()))
+                    )
+                    .map(|filter| (layer.inner_layer.with_filter(filter), guard))
+            })
+        }
+    }
+    .into()
+}
+
+/// A convenience macro to do `new!()` followed by creating and starting a
+/// `FileWatcher` and `SystemInfoWatcher` within a single step.
+///
+/// Returns a `TelemetryLayer` and a drop guard. Here, the drop guard will flush
+/// any remaining telemetry to the disk.
+///
+/// Use this macro if you are using `fuel-telemetry` along with other `tracing`
+/// `Layer`s within your application, or you have your own `tracing`
+/// `Subscriber`.
+///
+/// Otherwise, if you are using `fuel-telemetry` as your only `tracing`
+/// `Subscriber`, you should instead use `new_with_watchers_and_init!()`.
+///
+/// ```text
+/// use fuel_telemetry::prelude::*;
+///
+/// let (telemetry_layer, _guard) = fuel_telemetry::new_with_watchers!()?;
+/// tracing_subscriber::registry().with(telemetry_layer).init();
+///
+/// info_telemetry!("This event will be sent to InfluxBD");
+/// ```
+#[proc_macro]
+pub fn new_with_watchers(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let start_watchers = start_watchers();
+
+    quote! {
+        {
+            #start_watchers
+            fuel_telemetry::new!()
+        }
+    }
+    .into()
+}
+
+/// A convenience macro to do `new_with_watchers!()` followed by setting the
+/// `TracingLayer` as the global default `Subscriber`.
+///
+/// Returns a `TelemetryLayer` and a drop guard. Here, the drop guard will flush
+/// any remaining telemetry to the disk.
+///
+/// Use this macro if you are using `fuel-telemetry` as your only `tracing`
+/// `Subscriber`.
+///
+/// Otherwise, if you are using `fuel-telemetry` along with other `tracing`
+/// `Layer`s within your application, you should instead use `new_with_watchers!()`.
+///
+/// ```text
+/// use fuel_telemetry::prelude::*;
+///
+/// let (telemetry_layer, _guard) = fuel_telemetry::new_with_watchers_and_init!()?;
+///
+/// info_telemetry!("This event will be sent to InfluxBD");
+/// ```
+#[proc_macro]
+pub fn new_with_watchers_and_init(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let args: Vec<String> = std::env::args().collect();
+    let mut crate_name = String::new();
+    let mut crate_type = String::new();
+
+    // During macro expansion, we extract the crate name and type from the
+    // compiler's command line arguments, as this is the only time and place
+    // this information is available.
+    for window in args.windows(2) {
+        match window[0].as_str() {
+            "--crate-name" => crate_name = window[1].clone(),
+            "--crate-type" => crate_type = window[1].clone(),
+            _ => {}
+        }
+    }
+
+    // If the crate is a library, and it is not the `fuel_telemetry` crate,
+    // then generate a compiler error so we cannot continue!
+    if crate_type == "lib" && crate_name != "fuel_telemetry" {
+        return quote! {
+            {
+                compile_error!("new_with_watchers_and_init!() cannot be called within a library")
+            }
+        }
+        .into();
+    }
+
+    quote! {
+        {
+            fuel_telemetry::new_with_watchers!().map(|(layer, guard)| {
+                use fuel_telemetry::__reexport_SubscriberInitExt;
+                use fuel_telemetry::__reexport_tracing_subscriber;
+                use fuel_telemetry::__reexport_tracing_subscriber_SubscriberExt;
+
+                __reexport_tracing_subscriber::registry()
+                    .with(layer)
+                    .init();
+
+                guard
+            })
+        }
+    }
+    .into()
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,134 @@
+use base64::DecodeError;
+use std::{io, path::PathBuf, string::FromUtf8Error};
+use thiserror::Error;
+
+#[derive(Error, Clone, PartialEq)]
+pub enum TelemetryError {
+    //
+    // External errors
+    //
+    #[error("Base64 error: {0}")]
+    Base64(#[from] DecodeError),
+    #[error("IO error: {0}")]
+    IO(String),
+    #[error("Nix error: {0}")]
+    Nix(String),
+    #[error("Parse error: {0}")]
+    Parse(String),
+    #[error("Reqwest error: {0}")]
+    Reqwest(String),
+    #[error("Request clone failed")]
+    ReqwestCloneFailed,
+    #[error("UTF-8 error: {0}")]
+    Utf8(String),
+
+    //
+    // General errors
+    //
+    #[error("Invalid config: {0}")]
+    InvalidConfig(String),
+    #[error("Invalid client")]
+    InvalidClient,
+    #[error("Invalid 'RUST_LOG' filter: {0}")]
+    InvalidEnvFilter(String),
+    #[error("Home directory is invalid: {0}")]
+    InvalidHomeDir(String),
+    #[error("Log directory is invalid: {0}")]
+    InvalidLogDir(String),
+    #[error("Logfile is invalid: {0}/{1}")]
+    InvalidLogFile(String, PathBuf),
+    #[error("Invalid request")]
+    InvalidRequest,
+    #[error("Temporary directory is invalid: {0}")]
+    InvalidTmpDir(String),
+    #[error("Do not use 'TelemetryLayer::new()' directly, instead use the constructor macros")]
+    InvalidUsage,
+    #[error("Home directory is unreachable")]
+    UnreachableHomeDir,
+    #[error("Crate name is unreadable")]
+    UnreadableCrateName,
+
+    //
+    // FileWatcher errors
+    //,
+    #[error("Tracing event is invalid: {0}")]
+    InvalidTracingEvent(String),
+    #[error("Tracing regex is invalid: {0}")]
+    InvalidTracingRegex(#[from] regex::Error),
+    #[error("Tracing payload is invalid: {0}")]
+    InvalidTracingPayload(String),
+
+    // Mock error for testing
+    #[error("Mock error")]
+    Mock,
+}
+
+/// Convenience impl that dereferences the error
+/// so that we can use the error with `?`
+impl From<&TelemetryError> for TelemetryError {
+    fn from(err: &TelemetryError) -> Self {
+        err.clone()
+    }
+}
+
+impl From<TelemetryError> for String {
+    fn from(err: TelemetryError) -> Self {
+        err.to_string()
+    }
+}
+
+impl std::fmt::Debug for TelemetryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+//
+// The following impls are convenience impls that convert errors into our
+// `TelemetryError` variant. We do this because we want to use the `?` operator
+// and can't use `?` directly because the source errors don't implement
+// `Clone`.
+//
+
+macro_rules! impl_error_from {
+    ($from:ty, $variant:ident) => {
+        impl From<$from> for TelemetryError {
+            fn from(err: $from) -> Self {
+                Self::$variant(err.to_string())
+            }
+        }
+    };
+}
+
+impl_error_from!(io::Error, IO);
+impl_error_from!(nix::Error, Nix);
+impl_error_from!(std::num::ParseIntError, Parse);
+impl_error_from!(reqwest::Error, Reqwest);
+impl_error_from!(FromUtf8Error, Utf8);
+
+#[derive(Debug, PartialEq)]
+pub enum WatcherError {
+    Recoverable(TelemetryError),
+    Fatal(TelemetryError),
+}
+
+impl WatcherError {
+    pub fn is_fatal(&self) -> bool {
+        matches!(self, WatcherError::Fatal(_))
+    }
+}
+
+impl From<TelemetryError> for WatcherError {
+    fn from(err: TelemetryError) -> Self {
+        // Default to fatal, then be explicit about recoverable errors
+        WatcherError::Fatal(err)
+    }
+}
+
+pub fn into_fatal<E: Into<TelemetryError>>(err: E) -> WatcherError {
+    WatcherError::Fatal(err.into())
+}
+
+pub fn into_recoverable<E: Into<TelemetryError>>(err: E) -> WatcherError {
+    WatcherError::Recoverable(err.into())
+}

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -1,0 +1,1470 @@
+use crate::{
+    daemonise, enforce_singleton, into_recoverable, telemetry_config, EnvSetting, Result,
+    TelemetryError, WatcherResult,
+};
+
+use base64::{engine::general_purpose::STANDARD, DecodeError, Engine};
+use chrono::NaiveDateTime;
+use influxdb_line_protocol::LineProtocolBuilder;
+use nix::{
+    fcntl::{Flock, FlockArg},
+    sys::signal::{kill, Signal::SIGKILL},
+    unistd::{getpid, Pid},
+};
+use regex::{Captures, Regex};
+use reqwest::blocking::{Client, Request, RequestBuilder};
+use std::fs::ReadDir;
+use std::{
+    collections::HashMap,
+    env::var,
+    fs::{read_dir, remove_file, File, OpenOptions},
+    io::{BufRead, BufReader, Read, Write},
+    path::{Path, PathBuf},
+    process::exit,
+    sync::{
+        atomic::{AtomicBool, AtomicI32, Ordering},
+        LazyLock,
+    },
+    thread::sleep,
+    time::Duration,
+};
+
+//
+// Module config
+//
+
+const PROCESS_NAME: &str = "telemetry-file-watcher";
+const INFLUXDB_ORG: &str = "Dev%20Team";
+const INFLUXDB_BUCKET: &str = "telemetry";
+const INFLUXDB_URL: &str = "https://us-east-1-1.aws.cloud2.influxdata.com";
+const INFLUXDB_TOKEN: &str =
+    "l7Sho-XGD9BfGLQrKWwoBub-hC0gqJ5xRS2zz4pkjb6cGyBJZUQpw7qpwTfXTFGLXufCh7ZmQWv4bUtAsT60Ag==";
+
+/// Configuration for `FileWatcher`
+#[derive(Debug, Clone)]
+struct FileWatcherConfig {
+    // The path to its lockfile
+    lockfile: PathBuf,
+    // The path to its logfile
+    logfile: PathBuf,
+    // The token to use to authenticate with InfluxDB
+    influxdb_token: String,
+    // The URL of the InfluxDB instance
+    influxdb_url: String,
+    // The interval to poll for aged-out telemetry files
+    poll_interval: Duration,
+}
+
+/// Get the `FileWatcher` configuration
+///
+/// This function returns the `'static` `FileWatcher` configuration.
+fn config() -> Result<&'static FileWatcherConfig> {
+    static FILEWATCHER_CONFIG: LazyLock<Result<FileWatcherConfig>> = LazyLock::new(|| {
+        let get_env = |key, default| EnvSetting::new(key, default).get();
+
+        // Since we use an hourly appender, we default to polling every hour
+        let poll_interval = get_env("FILEWATCHER_POLL_INTERVAL", "3600").parse()?;
+
+        // Format the InfluxDB URL (the org name needs to be URL-encoded)
+        let base_url = get_env("INFLUXDB_URL", INFLUXDB_URL);
+        let org = get_env("INFLUXDB_ORG", INFLUXDB_ORG);
+        let bucket = get_env("INFLUXDB_BUCKET", INFLUXDB_BUCKET);
+        let influxdb_url = format!(
+            "{}/api/v2/write?org={}&bucket={}&precision=ns",
+            base_url, org, bucket
+        );
+
+        Ok(FileWatcherConfig {
+            poll_interval: Duration::from_secs(poll_interval),
+            influxdb_token: get_env("INFLUXDB_TOKEN", INFLUXDB_TOKEN),
+            influxdb_url,
+            lockfile: Path::new(&telemetry_config()?.fuelup_tmp)
+                .join(format!("{}.lock", PROCESS_NAME)),
+            logfile: Path::new(&telemetry_config()?.fuelup_log)
+                .join(format!("{}.log", PROCESS_NAME)),
+        })
+    });
+
+    FILEWATCHER_CONFIG
+        .as_ref()
+        .map_err(|e| TelemetryError::InvalidConfig(e.to_string()))
+}
+
+//
+// FileWatcher implementation
+//
+
+/// A `FileWatcher` polls for aged-out telemetry files and sends them to InfluxDB
+#[derive(Default)]
+pub struct FileWatcher {
+    // The client used to send requests to InfluxDB
+    client: Option<Client>,
+    // The request to send to InfluxDB
+    request: Option<Request>,
+}
+
+// Prevent recursive calls to start()
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+/// The PID of the currently running `FileWatcher` daemon
+pub static PID: AtomicI32 = AtomicI32::new(0);
+
+/// A regex to parse telemetry events
+static TELEMETRY_EVENT_REGEX: LazyLock<Result<Regex>> = LazyLock::new(|| {
+    Ok(Regex::new(
+        r"(?x)
+        ^                                                                         \s*
+        (?P<timestamp>[^\s]+)                                                     \s+
+        (?P<level>(TRACE|DEBUG|INFO|WARN|ERROR))                                  \s+
+        (?P<triple>.*?):(?P<os>.*?):(?P<os_version>.*?)                           \s+
+        (?P<crate_pkg_name>[^\s]+):(?P<crate_pkg_version>[^\s]+):(?P<file>[^\s]+) \s+
+        (?P<trace_id>[^\s]+)                                                      \s+
+        (?P<payload>.*)                                                           \s*
+        $
+        ",
+    )?)
+});
+
+/// A regex to parse telemetry payloads
+///
+/// Event payloads have the following formats:
+///
+/// ```text
+/// - <message_only>
+/// - [<span1>:<span2>:...:] [<message>] [<left1>= <right1> <left2>= <right2> ...]
+/// ```
+static TELEMETRY_PAYLOAD_REGEX: LazyLock<Result<Regex>> = LazyLock::new(|| {
+    Ok(Regex::new(
+        r"(?x)
+        (?P<span>[^\s\:][^\:]*?[^\s\:]*?) :
+        | (?:^|\s+) (?P<message_only>[^\=]+) \s* $
+        | (?:^|\s+) (?P<message>[^\=]+) \s+
+        | (?P<left>[^\s\=]+) = (?P<right>[^\=]+) (?:\s+|$)
+        ",
+    )?)
+});
+
+impl FileWatcher {
+    /// Create a new `FileWatcher`
+    ///
+    /// Warning: This function should only be called in applications and not
+    /// within libraries as it will clobber any set by the application.
+    ///
+    /// Warning: If you will be creating a `FileWatcher` and a `TelemetryLayer`,
+    /// you must create the `FileWatcher` before the `TelemetryLayer` as there is
+    /// a race condition in the thread runtime of `tracing` and the tokio runtime
+    /// of `Reqwest`. Swapping order of the two could lead to possible deadlocks.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start the `FileWatcher`
+    ///
+    /// This function forks and has the parent immediately return. The forked
+    /// off child then daemonises to poll for aged-out telemetry files, sending
+    /// them to InfluxDB, and exits once there are no more files to process.
+    pub fn start(&mut self) -> WatcherResult<()> {
+        self.start_with_helpers(&DefaultStartHelpers)
+    }
+
+    fn start_with_helpers(&mut self, helpers: &impl StartHelpers) -> WatcherResult<()> {
+        if var("FUELUP_NO_TELEMETRY").is_ok() {
+            // If telemetry is disabled, immediately return
+            return Ok(());
+        }
+
+        let logfile = &config().map_err(into_recoverable)?.logfile;
+
+        if STARTED.load(Ordering::Relaxed) {
+            return Ok(());
+        } else {
+            STARTED.store(true, Ordering::Relaxed);
+        }
+
+        match helpers.daemonise(logfile) {
+            Ok(Some(pid)) => {
+                // We are the parent, so record the PID then immediately return
+                PID.store(pid.as_raw(), Ordering::Relaxed);
+                return Ok(());
+            }
+            Err(e) => {
+                // Couldn't daemonise, so clear globals before returning the error
+                STARTED.store(false, Ordering::Relaxed);
+                PID.store(0, Ordering::Relaxed);
+                return Err(e);
+            }
+            Ok(None) => {
+                // We are the child process, so continue as the `FileWatcher`...
+                PID.store(getpid().as_raw(), Ordering::Relaxed);
+            }
+        }
+
+        // From here on, we are no longer the original process, so the caller should
+        // treat errors as fatal. This means that on error the process should exit
+        // immediately as there should not be two identical flows of execution
+        // from the caller's perspective.
+
+        // Cache the client and request so we don't recreate them each time
+        self.client = Some(Client::new());
+        self.request = Some(helpers.build_request(self)?);
+
+        loop {
+            // Enforce a singleton to ensure we are the only process submitting
+            // telemetry to InfluxDB
+            let _lock = helpers.enforce_singleton(&config()?.lockfile)?;
+
+            // Poll for aged-out telemetry files
+            let directory_empty = helpers.poll_directory(self)?;
+
+            if directory_empty {
+                helpers.exit(0);
+            }
+
+            // Sleep for the configured interval before polling again
+            helpers.sleep(config()?.poll_interval);
+        }
+    }
+
+    /// Kill the `FileWatcher` daemon if one is running
+    pub fn kill() -> Result<bool> {
+        let pid = PID.load(Ordering::Relaxed);
+
+        if pid == 0 {
+            return Ok(false);
+        }
+
+        kill(Pid::from_raw(pid), SIGKILL)?;
+        PID.store(0, Ordering::Relaxed);
+        Ok(true)
+    }
+
+    /// Poll for aged-out telemetry files
+    fn poll_directory(&self) -> Result<bool> {
+        self.poll_directory_with_helpers(&mut DefaultPollDirectoryHelpers)
+    }
+
+    fn poll_directory_with_helpers(&self, helpers: &mut impl PollDirectoryHelpers) -> Result<bool> {
+        for file in helpers.find_telemetry_files(false)? {
+            // Lock the telemetry file to prevent being submitted twice
+            let locked_file = helpers
+                .flock(
+                    OpenOptions::new().read(true).open(&file)?,
+                    FlockArg::LockExclusiveNonblock,
+                )
+                .map_err(|(_, e)| e)?;
+
+            // Read the telemetry file line by line
+            let mut body = Vec::new();
+            let lines = helpers.buffered_reader(locked_file.try_clone()?)?;
+
+            for base64_line in lines {
+                // First, decode the Base64 line
+                let decoded_line = helpers.base64_decode(&base64_line)?;
+                let line = helpers.string_from_utf8(decoded_line)?;
+
+                let (event, spans_long, spans_short, fields) = helpers.parse_event(&line)?;
+                let line_protocol =
+                    helpers.build_line_protocol(&event, &spans_long, &spans_short, &fields);
+
+                body.push(helpers.string_from_utf8(line_protocol)?);
+            }
+
+            if body.is_empty() {
+                continue;
+            }
+
+            // Do not cache creating this request in the constructor then attempt
+            // to use build_from_parts() here, because the `Client` used to build
+            // the request is in another castle^Wprocess (we've since forked many
+            // times), and so a `Client::new()` here will deadlock as it will
+            // try to connect to a non-existant connection pool.
+            let request = helpers.build_request(self, &body)?;
+
+            if helpers.send_request(request)? {
+                // Only remove the telemetry file if successful
+                helpers.remove_file(&file)?;
+            }
+        }
+
+        // Return false if there are pending telemetry files to process
+        // regardless of age so that we keep going until there's no more work to
+        // be done
+        Ok(helpers.find_telemetry_files(true)?.is_empty())
+    }
+
+    /// Last resort logging of errors, only to be used by the caller when there
+    /// is no other way to report an error.
+    pub fn log_error(message: &str) -> Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&config()?.logfile)?;
+
+        Ok(writeln!(file, "{}", message)?)
+    }
+}
+
+trait StartHelpers {
+    fn daemonise(&self, logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+        daemonise(logfile)
+    }
+
+    fn build_request(&self, file_watcher: &FileWatcher) -> Result<Request> {
+        Ok(file_watcher
+            .client
+            .as_ref()
+            .ok_or(TelemetryError::InvalidClient)?
+            .post(&config()?.influxdb_url)
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .header("Accept", "application/json")
+            .header(
+                "Authorization",
+                format!("Token {}", config()?.influxdb_token.clone()),
+            )
+            .build()?)
+    }
+
+    fn enforce_singleton(&self, lockfile_path: &Path) -> Result<Flock<File>> {
+        enforce_singleton(lockfile_path)
+    }
+
+    fn poll_directory(&self, file_watcher: &FileWatcher) -> Result<bool> {
+        file_watcher.poll_directory()
+    }
+
+    fn exit(&self, code: i32) {
+        exit(code)
+    }
+
+    fn sleep(&self, duration: Duration) {
+        sleep(duration)
+    }
+}
+
+struct DefaultStartHelpers;
+impl StartHelpers for DefaultStartHelpers {}
+
+trait PollDirectoryHelpers {
+    fn find_telemetry_files(&mut self, ignore_age: bool) -> Result<Vec<PathBuf>> {
+        find_telemetry_files(ignore_age)
+    }
+
+    fn flock(
+        &self,
+        file: File,
+        flags: FlockArg,
+    ) -> std::result::Result<Flock<File>, (File, nix::errno::Errno)> {
+        Flock::lock(file, flags)
+    }
+
+    fn buffered_reader<R: Read>(
+        &self,
+        file: R,
+    ) -> std::result::Result<Vec<String>, std::io::Error> {
+        BufReader::new(file)
+            .lines()
+            .collect::<std::result::Result<Vec<_>, _>>()
+    }
+
+    fn base64_decode(&self, line: &str) -> std::result::Result<Vec<u8>, DecodeError> {
+        STANDARD.decode(line.as_bytes())
+    }
+
+    fn string_from_utf8(
+        &mut self,
+        bytes: Vec<u8>,
+    ) -> std::result::Result<String, std::string::FromUtf8Error> {
+        String::from_utf8(bytes)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn parse_event<'a>(
+        &self,
+        line: &'a str,
+    ) -> Result<(
+        Captures<'a>,
+        Vec<String>,
+        Vec<String>,
+        HashMap<&'a str, String>,
+    )> {
+        let event = TELEMETRY_EVENT_REGEX
+            .as_ref()?
+            .captures(line)
+            .ok_or_else(|| TelemetryError::InvalidTracingEvent(line.to_string()))?;
+
+        let payload = event
+            .name("payload")
+            .ok_or_else(|| TelemetryError::InvalidTracingPayload(line.to_string()))?;
+
+        let (mut spans_long, mut spans_short, mut fields) = (vec![], vec![], HashMap::new());
+
+        for capture in TELEMETRY_PAYLOAD_REGEX
+            .as_ref()?
+            .captures_iter(payload.into())
+        {
+            if let Some(span) = capture.name("span") {
+                let span_str = span.as_str();
+                spans_long.push(span_str.to_string());
+                spans_short.push(span_str.split('{').next().unwrap_or(span_str).to_string());
+            } else if let Some(message) = capture.name("message") {
+                fields.insert("message", message.as_str().to_string());
+            } else if let Some(message_only) = capture.name("message_only") {
+                fields.insert("message", message_only.as_str().to_string());
+            } else if let (Some(left), Some(right)) = (capture.name("left"), capture.name("right"))
+            {
+                fields.insert(left.as_str(), right.as_str().to_string());
+            }
+        }
+
+        Ok((event, spans_long, spans_short, fields))
+    }
+
+    fn build_line_protocol(
+        &self,
+        event: &Captures<'_>,
+        spans_long: &[String],
+        spans_short: &[String],
+        fields: &HashMap<&str, String>,
+    ) -> Vec<u8> {
+        let mut line_protocol_builder = LineProtocolBuilder::new()
+            .measurement(event.name("crate_pkg_name").map_or("", |m| m.as_str()))
+            .tag(
+                "version",
+                event.name("crate_pkg_version").map_or("", |m| m.as_str()),
+            )
+            .tag("file", event.name("file").map_or("", |m| m.as_str()))
+            .tag("spans", &spans_short.join(":"))
+            .tag(
+                "trace_id",
+                event.name("trace_id").map_or("", |m| m.as_str()),
+            )
+            .field("spans_long", spans_long.join(":").as_str())
+            .field("triple", event.name("triple").map_or("", |m| m.as_str()));
+
+        for (key, value) in fields {
+            line_protocol_builder = line_protocol_builder.field(key, value.as_str());
+        }
+
+        // Set the timestamp of the LineProtocol. Here we force a `.9` decimal
+        // format rather than use the default nanoseconds format as InfluxDB seems
+        // to have issues parsing datetime data
+        let line_protocol_builder = line_protocol_builder.timestamp(
+            event
+                .name("timestamp")
+                .and_then(|m| {
+                    // Within `lib.rs:format_event()` we deliberately stick with
+                    // Zulu however we use `%Z` format here as external apps writing
+                    // telemetry files may use other timezone names
+                    NaiveDateTime::parse_from_str(m.as_str(), "%Y-%m-%dT%H:%M:%S%.9f%Z")
+                        .ok()
+                        .map(|dt| dt.and_utc().timestamp_nanos_opt())
+                })
+                .flatten()
+                .unwrap_or(0),
+        );
+
+        line_protocol_builder.close_line().build()
+    }
+
+    fn build_request(&self, file_watcher: &FileWatcher, body: &[String]) -> Result<RequestBuilder> {
+        Ok(RequestBuilder::from_parts(
+            file_watcher
+                .client
+                .as_ref()
+                .ok_or(TelemetryError::InvalidClient)?
+                .clone(),
+            file_watcher
+                .request
+                .as_ref()
+                .ok_or(TelemetryError::InvalidRequest)?
+                .try_clone()
+                .ok_or(TelemetryError::ReqwestCloneFailed)?,
+        )
+        .body(body.join("\n")))
+    }
+
+    fn send_request(&self, request: RequestBuilder) -> Result<bool> {
+        Ok(request.send().is_ok_and(|r| r.status().is_success()))
+    }
+
+    fn remove_file(&self, file: &Path) -> std::io::Result<()> {
+        remove_file(file)
+    }
+}
+
+struct DefaultPollDirectoryHelpers;
+impl PollDirectoryHelpers for DefaultPollDirectoryHelpers {}
+
+/// Find telemetry files
+///
+/// This function finds all telemetry files in the configured directory.
+///
+/// If `ignore_age` is true, return telemetry files regardless of age, otherwise
+/// only return files that are older than the configured poll interval.
+fn find_telemetry_files(ignore_age: bool) -> Result<Vec<PathBuf>> {
+    find_telemetry_files_with_read_dir_fn(ignore_age, |path| read_dir(path))
+}
+
+fn find_telemetry_files_with_read_dir_fn(
+    ignore_age: bool,
+    read_dir_fn: impl FnOnce(&str) -> std::result::Result<ReadDir, std::io::Error>,
+) -> Result<Vec<PathBuf>> {
+    let poll_interval = config()?.poll_interval;
+    let telemetry_dir = &telemetry_config()?.fuelup_tmp;
+
+    // Filter out files not containing `.telemetry.` in the filename
+    //
+    // Also, ignore file age if `ignore_age` is true
+    read_dir_fn(telemetry_dir)?
+        .filter_map(std::result::Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_file())
+        .filter(|p| p.to_string_lossy().contains(".telemetry."))
+        .filter_map(|path| {
+            if ignore_age
+                || poll_interval < path.metadata().ok()?.modified().ok()?.elapsed().ok()?
+            {
+                Some(Ok(path))
+            } else {
+                None
+            }
+        })
+        .collect::<Result<Vec<_>>>()
+}
+
+#[cfg(test)]
+mod config {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use dirs::home_dir;
+    use rusty_fork::rusty_fork_test;
+    use std::env::set_var;
+
+    rusty_fork_test! {
+        #[test]
+        fn all_unset() {
+            let config = config().unwrap();
+
+            assert_eq!(
+                config.lockfile,
+                Path::new(
+                    &home_dir()
+                        .unwrap()
+                        .join(format!(".fuelup/tmp/{}.lock", PROCESS_NAME))
+                )
+            );
+            assert_eq!(
+                config.logfile,
+                Path::new(
+                    &home_dir()
+                        .unwrap()
+                        .join(format!(".fuelup/log/{}.log", PROCESS_NAME))
+                )
+            );
+            assert_eq!(config.poll_interval, Duration::from_secs(3600));
+            assert_eq!(config.influxdb_token, INFLUXDB_TOKEN);
+
+            assert_eq!(config.influxdb_url, format!(
+                "{}/api/v2/write?org={}&bucket={}&precision=ns",
+                INFLUXDB_URL,
+                INFLUXDB_ORG,
+                INFLUXDB_BUCKET
+            ));
+        }
+
+        #[test]
+        fn poll_interval_set() {
+            set_var("FILEWATCHER_POLL_INTERVAL", "2222");
+
+            let config = config().unwrap();
+            assert_eq!(config.poll_interval, Duration::from_secs(2222));
+        }
+
+        #[test]
+        fn poll_interval_invalid() {
+            set_var("FILEWATCHER_POLL_INTERVAL", "invalid");
+
+            let config = config();
+            assert_eq!(
+                config.err(),
+                Some(TelemetryError::InvalidConfig(
+                    TelemetryError::Parse("invalid digit found in string".to_string()).into()
+                ))
+            );
+        }
+
+        #[test]
+        fn influxdb_url_set() {
+            set_var("INFLUXDB_URL", "http://localhost:8000");
+
+            let config = config().unwrap();
+            assert_eq!(
+                config.influxdb_url,
+                format!("{}/api/v2/write?org={}&bucket={}&precision=ns",
+                "http://localhost:8000",
+                INFLUXDB_ORG,
+                INFLUXDB_BUCKET
+            ));
+        }
+
+        #[test]
+        fn influxdb_org_set() {
+            set_var("INFLUXDB_ORG", "org-name");
+
+            let config = config().unwrap();
+            assert_eq!(config.influxdb_url, format!(
+                "{}/api/v2/write?org={}&bucket={}&precision=ns",
+                INFLUXDB_URL,
+                "org-name",
+                INFLUXDB_BUCKET
+            ));
+        }
+
+        #[test]
+        fn influxdb_bucket_set() {
+            set_var("INFLUXDB_BUCKET", "bucket-name");
+
+            let config = config().unwrap();
+            assert_eq!(config.influxdb_url, format!(
+                "{}/api/v2/write?org={}&bucket={}&precision=ns",
+                INFLUXDB_URL,
+                INFLUXDB_ORG,
+                "bucket-name"
+            ));
+        }
+
+        #[test]
+        fn all_set() {
+            setup_fuelup_home();
+            let fuelup_home = var("FUELUP_HOME").unwrap();
+
+            set_var("FILEWATCHER_POLL_INTERVAL", "2222");
+            set_var("INFLUXDB_URL", "http://localhost:8000");
+            set_var("INFLUXDB_ORG", "org-name");
+            set_var("INFLUXDB_BUCKET", "bucket-name");
+
+            let config = config().unwrap();
+
+            assert_eq!(
+                config.lockfile,
+                Path::new(&format!("{}/tmp/{}.lock", &fuelup_home, PROCESS_NAME))
+            );
+
+            assert_eq!(
+                config.logfile,
+                Path::new(&format!("{}/log/{}.log", &fuelup_home, PROCESS_NAME))
+            );
+            assert_eq!(config.poll_interval, Duration::from_secs(2222));
+            assert_eq!(config.influxdb_token, INFLUXDB_TOKEN);
+            assert_eq!(
+                config.influxdb_url,
+                format!("{}/api/v2/write?org={}&bucket={}&precision=ns",
+                    "http://localhost:8000",
+                    "org-name",
+                    "bucket-name"
+                )
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod new {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn new() {
+            let file_watcher = FileWatcher::new();
+
+            assert!(file_watcher.client.is_none());
+            assert!(file_watcher.request.is_none());
+        }
+    }
+}
+
+#[cfg(test)]
+mod start {
+    use super::*;
+    use crate::{errors::into_fatal, setup_fuelup_home, WatcherError};
+    use nix::{
+        sys::wait::{waitpid, WaitStatus},
+        unistd::{dup2, fork, pipe, ForkResult},
+    };
+    use rusty_fork::rusty_fork_test;
+    use std::{
+        env::set_var,
+        fs::File,
+        io::{stdout, Read, Write},
+        os::fd::{AsRawFd, FromRawFd, IntoRawFd},
+    };
+
+    rusty_fork_test! {
+        #[test]
+        fn opted_out_is_true() {
+            set_var("FUELUP_NO_TELEMETRY", "true");
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start();
+
+            // Make sure it didn't continue and init values
+            assert!(matches!(result, Ok(())));
+            assert!(file_watcher.client.is_none());
+            assert!(file_watcher.request.is_none());
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn opted_out_is_empty() {
+            // Even though it's empty, we only care if it's set
+            set_var("FUELUP_NO_TELEMETRY", "");
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start();
+
+            // Make sure it didn't continue and init values
+            assert!(matches!(result, Ok(())));
+            assert!(file_watcher.client.is_none());
+            assert!(file_watcher.request.is_none());
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn already_started() {
+            STARTED.store(true, Ordering::Relaxed);
+            PID.store(1, Ordering::Relaxed);
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start();
+
+            // Make sure it didn't continue and init values
+            assert!(matches!(result, Ok(())));
+            assert!(file_watcher.client.is_none());
+            assert!(file_watcher.request.is_none());
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1);
+
+            // Try to start it again to test re-entrance
+            let result = file_watcher.start();
+
+            assert!(matches!(result, Ok(())));
+            assert!(file_watcher.client.is_none());
+            assert!(file_watcher.request.is_none());
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1);
+        }
+
+        #[test]
+        fn daemonise_failed() {
+            struct DaemoniseFailed;
+
+            impl StartHelpers for DaemoniseFailed {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Err(into_fatal(TelemetryError::Mock))
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start_with_helpers(&DaemoniseFailed);
+
+            assert_eq!(
+                result.err(),
+                Some(WatcherError::Fatal(TelemetryError::Mock))
+            );
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn daemonise_is_parent() {
+            struct DaemoniseIsParent;
+
+            impl StartHelpers for DaemoniseIsParent {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(Some(Pid::from_raw(1337)))
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start_with_helpers(&DaemoniseIsParent);
+
+            assert_eq!(result, Ok(()));
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1337);
+        }
+
+        #[test]
+        fn build_request_invalid_client() {
+            struct BuildRequestInvalidClient;
+
+            impl StartHelpers for BuildRequestInvalidClient {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+
+                fn build_request(&self, _file_watcher: &FileWatcher) -> Result<Request> {
+                    Err(TelemetryError::InvalidClient)
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start_with_helpers(&BuildRequestInvalidClient);
+
+            assert_eq!(
+                result,
+                Err(WatcherError::Fatal(TelemetryError::InvalidClient))
+            );
+        }
+
+        #[test]
+        fn build_request_build_failed() {
+            setup_fuelup_home();
+
+            struct BuildRequestBuildFailed;
+
+            impl StartHelpers for BuildRequestBuildFailed {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+
+                fn build_request(&self, _file_watcher: &FileWatcher) -> Result<Request> {
+                    // Builder errors are private, so generate a real one
+                    Ok(Client::new()
+                        .post("http://localhost")
+                        .header("Invalid Header", "")
+                        .build()?)
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start_with_helpers(&BuildRequestBuildFailed);
+
+            assert_eq!(
+                result,
+                Err(WatcherError::Fatal(TelemetryError::Reqwest(
+                    "builder error".to_string()
+                )))
+            );
+        }
+
+        #[test]
+        fn enforce_singleton_failed() {
+            struct EnforceSingletonFailed;
+
+            impl StartHelpers for EnforceSingletonFailed {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+
+                fn enforce_singleton(&self, _lockfile_path: &Path) -> Result<Flock<File>> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start_with_helpers(&EnforceSingletonFailed);
+
+            assert_eq!(result, Err(WatcherError::Fatal(TelemetryError::Mock)));
+        }
+
+        #[test]
+        fn poll_directory_failed() {
+            setup_fuelup_home();
+
+            struct PollDirectoryFailed;
+
+            impl StartHelpers for PollDirectoryFailed {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+
+                fn poll_directory(&self, _file_watcher: &FileWatcher) -> Result<bool> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let result = file_watcher.start_with_helpers(&PollDirectoryFailed);
+
+            assert_eq!(result, Err(WatcherError::Fatal(TelemetryError::Mock)));
+        }
+
+        #[test]
+        fn poll() {
+            setup_fuelup_home();
+
+            struct Poll;
+
+            impl StartHelpers for Poll {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    // Mock daemonising by not forking to become the child
+                    Ok(None)
+                }
+
+                fn poll_directory(&self, _file_watcher: &FileWatcher) -> Result<bool> {
+                    static HAS_POLLED: AtomicBool = AtomicBool::new(false);
+
+                    if !HAS_POLLED.load(Ordering::Relaxed) {
+                        HAS_POLLED.store(true, Ordering::Relaxed);
+
+                        // Send the PID so we can test it's as expected
+                        let file_watcher_pid = crate::file_watcher::PID
+                            .load(Ordering::Relaxed)
+                            .as_raw_fd()
+                            .to_ne_bytes();
+
+                        stdout().write_all(&file_watcher_pid).unwrap();
+                        stdout().flush().unwrap();
+
+                        Ok(false)
+                    } else {
+                        Ok(true)
+                    }
+                }
+
+                fn exit(&self, _code: i32) {
+                    // Test we actually exited via our expected code path
+                    exit(99)
+                }
+
+                fn sleep(&self, _duration: Duration) {
+                    // No Sleep Till Brooklyn
+                }
+            }
+
+            let (read_fd, write_fd) = pipe().unwrap();
+            let mut pipe_read = unsafe { File::from_raw_fd(read_fd.into_raw_fd()) };
+            let pipe_write = unsafe { File::from_raw_fd(write_fd.into_raw_fd()) };
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    drop(pipe_write);
+
+                    let mut pid_bytes = [0u8; std::mem::size_of::<Pid>()];
+                    pipe_read.read_exact(&mut pid_bytes).unwrap();
+
+                    let pid = Pid::from_raw(i32::from_ne_bytes(pid_bytes));
+                    assert_eq!(pid, child);
+
+                    match waitpid(child, None).unwrap() {
+                        WaitStatus::Exited(_, code) => {
+                            assert_eq!(code, 99);
+                        }
+                        _ => panic!("Child did not exit normally"),
+                    }
+                }
+                ForkResult::Child => {
+                    drop(pipe_read);
+                    dup2(pipe_write.as_raw_fd(), 1).unwrap();
+
+                    // Since we're mocking daemonising by not double forking in
+                    // the parent, we have to set the PID manually
+                    let pid_bytes = getpid().as_raw().to_ne_bytes();
+                    stdout().write_all(&pid_bytes).unwrap();
+                    stdout().flush().unwrap();
+
+                    let mut file_watcher = FileWatcher::new();
+                    let _ = file_watcher.start_with_helpers(&Poll);
+
+                    // Fallback status code
+                    exit(86);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod kill {
+    use super::*;
+    use nix::{
+        sys::{
+            signal::Signal,
+            wait::{waitpid, WaitPidFlag, WaitStatus},
+        },
+        unistd::{fork, ForkResult},
+    };
+    use rusty_fork::rusty_fork_test;
+    use std::thread::sleep;
+
+    rusty_fork_test! {
+        #[test]
+        fn kill_nobody() {
+            crate::file_watcher::PID.store(0, Ordering::Relaxed);
+            assert!(!FileWatcher::kill().unwrap());
+        }
+
+        #[test]
+        fn kill_file_watcher() {
+            let mut kill_called = false;
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    loop {
+                        match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+                            Ok(WaitStatus::StillAlive) => {
+                                if !kill_called {
+                                    // Since we're not daemonising, we have to set the PID manually
+                                    crate::file_watcher::PID
+                                        .store(child.as_raw(), Ordering::Relaxed);
+                                    assert!(FileWatcher::kill().unwrap());
+
+                                    kill_called = true;
+                                    continue;
+                                }
+                            }
+                            Ok(WaitStatus::Signaled(child_pid, signal, _)) => {
+                                assert_eq!(child_pid, child);
+                                assert_eq!(signal, Signal::SIGKILL);
+                                break;
+                            }
+                            _ => panic!("Child process terminated unexpectedly"),
+                        }
+                    }
+                }
+                ForkResult::Child => loop {
+                    sleep(Duration::from_secs(10));
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod poll_directory {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use rusty_fork::rusty_fork_test;
+    use std::{fs::File, io::Write, sync::OnceLock};
+
+    fn setup_test_file() -> PathBuf {
+        static TEST_FILE: OnceLock<PathBuf> = OnceLock::new();
+
+        let filename = TEST_FILE.get_or_init(|| {
+            let filename = format!("{}/{}", telemetry_config().unwrap().fuelup_tmp, "test.telemetry.file");
+
+            let mut file = File::create(Path::new(filename.as_str())).unwrap();
+            file.write_all(b"MjAyNS0wMy0xNlQxNDo0ODoxMC4wODQ4MDMwMDBaICBJTkZPIGFhcmNoNjQtYXBwbGUtZGFyd2luOkRhcndpbjoyMy42LjAgc2ltcGxlOjAuMS4wOmV4YW1wbGVzL3NpbXBsZS5ycyA0YjEyNDYyNy0wNjNiLTQwM2UtODEyZi02OWQxMzRlZjAxMzIgYXV0bzogZ0Z1ZWwh").unwrap();
+
+            PathBuf::from(filename)
+        });
+
+        filename.clone()
+    }
+
+    rusty_fork_test! {
+        #[test]
+        fn find_telemetry_files_failed() {
+            setup_fuelup_home();
+
+            struct FindTelemetryFilesFailed;
+
+            impl PollDirectoryHelpers for FindTelemetryFilesFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut FindTelemetryFilesFailed);
+
+            assert_eq!(result, Err(TelemetryError::Mock));
+       }
+
+        #[test]
+        fn find_telemetry_files_empty() {
+            setup_fuelup_home();
+
+            struct FindTelemetryFilesEmpty;
+
+            impl PollDirectoryHelpers for FindTelemetryFilesEmpty {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![])
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut FindTelemetryFilesEmpty);
+
+            assert_eq!(result, Ok(true));
+        }
+
+        #[test]
+        fn flock_failed() {
+            setup_fuelup_home();
+
+            struct FlockFailed;
+
+            impl PollDirectoryHelpers for FlockFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn flock(&self, file: File, _flags: FlockArg)-> std::result::Result<Flock<File>, (File, nix::errno::Errno)> {
+                    Err((file, nix::errno::Errno::EOWNERDEAD))
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut FlockFailed);
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::Nix(nix::errno::Errno::EOWNERDEAD.to_string()))
+            );
+        }
+
+        #[test]
+        fn buffered_reader_failed() {
+            setup_fuelup_home();
+
+            struct BufferedReaderFailed;
+
+            impl PollDirectoryHelpers for BufferedReaderFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn buffered_reader<R: Read>(&self, _file: R) -> std::result::Result<Vec<String>, std::io::Error> {
+                    Err(std::io::Error::new(std::io::ErrorKind::Other, "Mock error"))
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut BufferedReaderFailed);
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::IO("Mock error".to_string()))
+            );
+        }
+
+        #[test]
+        fn empty_file() {
+            setup_fuelup_home();
+
+            struct EmptyFile;
+
+            impl PollDirectoryHelpers for EmptyFile {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn buffered_reader<R: Read>(&self, _file: R) -> std::result::Result<Vec<String>, std::io::Error> {
+                    Ok(vec![])
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut EmptyFile);
+
+            // The test file was simulated as empty, so it should stick around
+            assert_eq!(result, Ok(false));
+        }
+
+        #[test]
+        fn base64_decode_failed() {
+            setup_fuelup_home();
+
+            struct Base64DecodeFailed;
+
+            impl PollDirectoryHelpers for Base64DecodeFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn base64_decode(&self, _line: &str) -> std::result::Result<Vec<u8>, DecodeError> {
+                    Err(DecodeError::InvalidLength(111222333444555))
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut Base64DecodeFailed);
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::Base64(DecodeError::InvalidLength(111222333444555)))
+            );
+        }
+
+        #[test]
+        fn string_from_utf8_failed() {
+            setup_fuelup_home();
+
+            struct StringFromUtf8Failed;
+
+            impl PollDirectoryHelpers for StringFromUtf8Failed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn string_from_utf8(&mut self, _bytes: Vec<u8>) -> std::result::Result<String, std::string::FromUtf8Error> {
+                    // Can't manually create an error, so simulate a failed UTF-8 conversion
+                    String::from_utf8(vec![0x80])
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut StringFromUtf8Failed);
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::Utf8("invalid utf-8 sequence of 1 bytes from index 0".to_string()))
+            );
+        }
+
+        #[test]
+        fn parse_event_failed() {
+            setup_fuelup_home();
+
+            struct ParseEventFailed;
+
+            impl PollDirectoryHelpers for ParseEventFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn parse_event<'a>(&self, _line: &'a str) -> Result<(
+                    Captures<'a>,
+                    Vec<String>,
+                    Vec<String>,
+                    HashMap<&'a str, String>,
+                )> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut ParseEventFailed);
+
+            assert_eq!(result, Err(TelemetryError::Mock));
+        }
+
+        #[test]
+        fn line_protocol_from_utf8_failed() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct LineProtocolFromUtf8Failed {
+                call_counter: usize,
+            }
+
+            impl PollDirectoryHelpers for LineProtocolFromUtf8Failed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn string_from_utf8(&mut self, bytes: Vec<u8>) -> std::result::Result<String, std::string::FromUtf8Error> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 2 {
+                        String::from_utf8(vec![0x80])
+                    } else {
+                        String::from_utf8(bytes)
+                    }
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut LineProtocolFromUtf8Failed::default());
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::Utf8("invalid utf-8 sequence of 1 bytes from index 0".to_string()))
+            );
+        }
+
+        #[test]
+        fn build_request_failed() {
+            setup_fuelup_home();
+
+            struct BuildRequestFailed;
+
+            impl PollDirectoryHelpers for BuildRequestFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn build_request(&self, _file_watcher: &FileWatcher, _body: &[String]) -> Result<RequestBuilder> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let file_watcher = FileWatcher::new();
+            let result = file_watcher.poll_directory_with_helpers(&mut BuildRequestFailed);
+
+            assert_eq!(result, Err(TelemetryError::Mock));
+        }
+
+        #[test]
+        fn send_request_failed() {
+            setup_fuelup_home();
+
+            struct SendRequestFailed;
+
+
+            impl PollDirectoryHelpers for SendRequestFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn send_request(&self, _request: RequestBuilder) -> Result<bool> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let start_helpers = DefaultStartHelpers;
+
+            file_watcher.client = Some(Client::new());
+            file_watcher.request = Some(start_helpers.build_request(&file_watcher).unwrap());
+
+            let result = file_watcher.poll_directory_with_helpers(&mut SendRequestFailed);
+            assert_eq!(result, Err(TelemetryError::Mock));
+
+            let test_file = setup_test_file();
+            assert!(test_file.exists());
+        }
+
+        #[test]
+        fn remove_file_failed() {
+            setup_fuelup_home();
+
+            struct RemoveFileFailed;
+
+            impl PollDirectoryHelpers for RemoveFileFailed {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    Ok(vec![setup_test_file()])
+                }
+
+                fn send_request(&self, _request: RequestBuilder) -> Result<bool> {
+                    Ok(true)
+                }
+
+                fn remove_file(&self, _file: &Path) -> std::io::Result<()> {
+                    Err(std::io::Error::new(std::io::ErrorKind::Other, "Mock error"))
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let start_helpers = DefaultStartHelpers;
+
+            file_watcher.client = Some(Client::new());
+            file_watcher.request = Some(start_helpers.build_request(&file_watcher).unwrap());
+
+            let result = file_watcher.poll_directory_with_helpers(&mut RemoveFileFailed);
+            assert_eq!(result, Err(TelemetryError::IO("Mock error".to_string())));
+
+            let test_file = setup_test_file();
+            assert!(test_file.exists());
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct AOk {
+                call_count: usize,
+            }
+
+            impl PollDirectoryHelpers for AOk {
+                fn find_telemetry_files(&mut self, _ignore_age: bool) -> Result<Vec<PathBuf>> {
+                    self.call_count += 1;
+
+                    if self.call_count == 2 {
+                        Ok(vec![])
+                    } else {
+                        Ok(vec![setup_test_file()])
+                    }
+                }
+
+                fn send_request(&self, _request: RequestBuilder) -> Result<bool> {
+                    Ok(true)
+                }
+            }
+
+            let mut file_watcher = FileWatcher::new();
+            let start_helpers = DefaultStartHelpers;
+
+            file_watcher.client = Some(Client::new());
+            file_watcher.request = Some(start_helpers.build_request(&file_watcher).unwrap());
+
+            let result = file_watcher.poll_directory_with_helpers(&mut AOk::default());
+            assert_eq!(result, Ok(true));
+
+            let test_file = setup_test_file();
+            assert!(!test_file.exists());
+        }
+    }
+}
+
+#[cfg(test)]
+mod find_telemetry_files {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use rusty_fork::rusty_fork_test;
+    use std::{fs::File, io::Write, time::SystemTime};
+
+    fn setup_test_files() {
+        for filename in [
+            "old-file.telemetry.file",
+            "new-file.telemetry.file",
+            "invalid.file.name",
+        ] {
+            let filepath = format!("{}/{}", telemetry_config().unwrap().fuelup_tmp, filename);
+            let mut file = File::create(Path::new(filepath.as_str())).unwrap();
+            file.write_all(b"MjAyNS0wMy0xNlQxNDo0ODoxMC4wODQ4MDMwMDBaICBJTkZPIGFhcmNoNjQtYXBwbGUtZGFyd2luOkRhcndpbjoyMy42LjAgc2ltcGxlOjAuMS4wOmV4YW1wbGVzL3NpbXBsZS5ycyA0YjEyNDYyNy0wNjNiLTQwM2UtODEyZi02OWQxMzRlZjAxMzIgYXV0bzogZ0Z1ZWwh").unwrap();
+        }
+
+        let old_file = File::open(Path::new(
+            format!(
+                "{}/old-file.telemetry.file",
+                telemetry_config().unwrap().fuelup_tmp
+            )
+            .as_str(),
+        ))
+        .unwrap();
+
+        old_file
+            .set_modified(
+                SystemTime::now() - Duration::from_secs(config().unwrap().poll_interval.as_secs()),
+            )
+            .unwrap();
+
+        for dir in ["dir1", "dir2", "dir3"] {
+            let dir = format!("{}/{}", telemetry_config().unwrap().fuelup_tmp, dir);
+            std::fs::create_dir_all(dir).unwrap();
+        }
+    }
+
+    rusty_fork_test! {
+        #[test]
+        fn read_dir_failed() {
+            setup_fuelup_home();
+            setup_test_files();
+
+            let result = find_telemetry_files_with_read_dir_fn(
+                false,
+                |_| Err(std::io::Error::new(std::io::ErrorKind::Other, "Mock error")),
+            );
+
+            assert_eq!(result, Err(TelemetryError::IO("Mock error".to_string())));
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+            setup_test_files();
+
+            let result = find_telemetry_files(false);
+
+            assert_eq!(result, Ok(vec![
+                PathBuf::from(format!("{}/old-file.telemetry.file", telemetry_config().unwrap().fuelup_tmp)),
+            ]));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1553 @@
+pub mod errors;
+pub mod file_watcher;
+pub mod process_watcher;
+pub mod systeminfo_watcher;
+pub mod telemetry_formatter;
+pub mod telemetry_layer;
+
+pub use errors::{into_fatal, into_recoverable, TelemetryError, WatcherError};
+pub use fuel_telemetry_macros::{new, new_with_watchers, new_with_watchers_and_init};
+pub use telemetry_formatter::TelemetryFormatter;
+pub use telemetry_layer::TelemetryLayer;
+pub use tracing::{debug, error, event, info, span, trace, warn, Level};
+pub use tracing_appender::non_blocking::WorkerGuard;
+
+pub mod prelude {
+    pub use crate::{
+        debug, debug_telemetry, error, error_telemetry, event, info, info_telemetry, span,
+        span_telemetry, trace, trace_telemetry, warn, warn_telemetry, Level, TelemetryLayer,
+    };
+}
+
+// Re-export tracing so proc_macros can use them
+pub use tracing as __reexport_tracing;
+pub use tracing_subscriber as __reexport_tracing_subscriber;
+pub use tracing_subscriber::filter::EnvFilter as __reexport_EnvFilter;
+pub use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt as __reexport_tracing_subscriber_SubscriberExt;
+pub use tracing_subscriber::util::SubscriberInitExt as __reexport_SubscriberInitExt;
+pub use tracing_subscriber::Layer as __reexport_Layer;
+
+use dirs::home_dir;
+use libc::{c_int, c_long};
+use nix::{
+    errno::Errno,
+    fcntl::{Flock, FlockArg},
+    sys::stat,
+    unistd::{
+        chdir, close, dup2, fork, getpid, pipe, read, setsid, sysconf, write, ForkResult, Pid,
+        SysconfVar,
+    },
+};
+use std::{
+    env::{current_exe, var, var_os},
+    fs::{create_dir_all, File, OpenOptions},
+    io::{stderr, stdout, Write},
+    os::fd::{AsRawFd, OwnedFd},
+    path::{Path, PathBuf},
+    process::exit,
+    sync::LazyLock,
+};
+
+// We need to close all file descriptors in `daemonise()`, but need to skip the
+// first three (0 = STDIN, 1 = STDOUT, 2 = STDERR) as we deal with stdio later
+const FIRST_NON_STDIO_FD: i32 = 3;
+
+// The lowest maximum file descriptor across Legacy Linux and MacOS
+const MIN_OPEN_MAX: i32 = 1024;
+
+// Result type for the crate
+pub type Result<T> = std::result::Result<T, TelemetryError>;
+
+// Result type from Watchers
+pub type WatcherResult<T> = std::result::Result<T, WatcherError>;
+
+//
+// Crate static configuration
+//
+
+/// A helper struct to get environment variables with a default value
+pub struct EnvSetting {
+    /// The name of the environment variable
+    name: &'static str,
+    /// The default value of the environment variable
+    default: &'static str,
+}
+
+impl EnvSetting {
+    /// Creates a new `EnvSetting`
+    ///
+    /// This function creates a new `EnvSetting` with the given name and default value.
+    ///
+    /// ```rust
+    /// use fuel_telemetry::EnvSetting;
+    ///
+    /// let env_setting = EnvSetting::new("FUELUP_HOME", ".fuelup");
+    /// ```
+    pub fn new(name: &'static str, default: &'static str) -> Self {
+        Self { name, default }
+    }
+
+    /// Gets the environment variable with a default value
+    ///
+    /// This function gets the environment variable with a default value.
+    ///
+    /// ```rust
+    /// use fuel_telemetry::EnvSetting;
+    ///
+    /// let env_setting = EnvSetting::new("FUELUP_HOME", ".fuelup");
+    /// let fuelup_home = env_setting.get();
+    /// ```
+    pub fn get(&self) -> String {
+        var(self.name).unwrap_or_else(|_| self.default.to_string())
+    }
+}
+
+/// Telemetry's global configuration
+///
+/// This struct contains the configuration for telemetry, to be used here and
+/// within its underlying modules.
+pub struct TelemetryConfig {
+    // The path to the fuelup tmp directory
+    fuelup_tmp: String,
+    // The path to the fuelup log directory
+    fuelup_log: String,
+}
+
+/// Get the global telemetry configuration
+///
+/// This function returns the global `'static` telemetry configuration.
+///
+/// ```rust
+/// use fuel_telemetry::telemetry_config;
+///
+/// let telemetry_config = telemetry_config();
+/// ```
+pub fn telemetry_config() -> Result<&'static TelemetryConfig> {
+    // Note: because we are using LazyLock, we cannot mock this function
+    // using helpers as they cannot be evaluated as non-const.
+    pub static TELEMETRY_CONFIG: LazyLock<Result<TelemetryConfig>> = LazyLock::new(|| {
+        let fuelup_home_env = EnvSetting {
+            name: "FUELUP_HOME",
+            default: ".fuelup",
+        };
+
+        let fuelup_tmp_env = EnvSetting {
+            name: "FUELUP_TMP",
+            default: "tmp",
+        };
+
+        let fuelup_log_env = EnvSetting {
+            name: "FUELUP_LOG",
+            default: "log",
+        };
+
+        // Tries to set the fuelup home directory from the environment, falling
+        // back to the $HOME/.fuelup
+        let fuelup_home = var_os(fuelup_home_env.name)
+            .map(PathBuf::from)
+            .or_else(|| home_dir().map(|dir| dir.join(fuelup_home_env.default)))
+            .ok_or(TelemetryError::UnreachableHomeDir)?
+            .into_os_string()
+            .into_string()
+            .map_err(|e| TelemetryError::InvalidHomeDir(e.to_string_lossy().into()))?;
+
+        // Tries to set the fuelup tmp directory from the environment, falling
+        // back to $FUELUP_HOME/tmp
+        let fuelup_tmp = var_os(fuelup_tmp_env.name)
+            .unwrap_or_else(|| {
+                PathBuf::from(fuelup_home.clone())
+                    .join(fuelup_tmp_env.default)
+                    .into_os_string()
+            })
+            .into_string()
+            .map_err(|e| TelemetryError::InvalidTmpDir(e.to_string_lossy().into()))?;
+
+        // Tries to set the fuelup log directory from the environment, falling
+        // back to $FUELUP_HOME/log
+        let fuelup_log = var_os(fuelup_log_env.name)
+            .unwrap_or_else(|| {
+                PathBuf::from(fuelup_home.clone())
+                    .join(fuelup_log_env.default)
+                    .into_os_string()
+            })
+            .into_string()
+            .map_err(|e| TelemetryError::InvalidLogDir(e.to_string_lossy().into()))?;
+
+        // Create the fuelup tmp and log directories if they don't exist
+        create_dir_all(&fuelup_tmp)?;
+        create_dir_all(&fuelup_log)?;
+
+        Ok(TelemetryConfig {
+            fuelup_tmp,
+            fuelup_log,
+        })
+    });
+
+    TELEMETRY_CONFIG
+        .as_ref()
+        .map_err(|e| TelemetryError::InvalidConfig(e.to_string()))
+}
+
+//
+// Convenience Macros
+//
+
+/// Enter a temporary `Span`, then generates an `Event` with telemetry enabled
+///
+/// Note: The `Span` name is currently hardcoded to "auto" as `tracing::span!`
+/// requires the name to be `const` as internally it is evaluated as a static,
+/// however getting the caller's function name in statics is experimental.
+///
+/// ```rust
+/// use fuel_telemetry::prelude::*;
+///
+/// span_telemetry!(Level::INFO, "This event will be sent to InfluxDB");
+/// ```
+#[macro_export]
+macro_rules! span_telemetry {
+    ($level:expr, $($arg:tt)*) => {
+        $crate::__reexport_tracing::span!($level, "auto", telemetry = true).in_scope(|| {
+            $crate::__reexport_tracing::event!($level, $($arg)*)
+        })
+    }
+}
+
+/// Generate an `ERROR` telemetry `Event`
+///
+/// ```rust
+/// use fuel_telemetry::prelude::*;
+///
+/// error_telemetry!("This error event will be sent to InfluxDB");
+/// ```
+#[macro_export]
+macro_rules! error_telemetry {
+    ($($arg:tt)*) => {{
+        span_telemetry!($crate::__reexport_tracing::Level::ERROR, $($arg)*);
+    }}
+}
+
+/// Generate a `WARN` telemetry `Event`
+///
+/// ```rust
+/// use fuel_telemetry::prelude::*;
+///
+/// warn_telemetry!("This warn event will be sent to InfluxDB");
+/// ```
+#[macro_export]
+macro_rules! warn_telemetry {
+    ($($arg:tt)*) => {{
+        span_telemetry!($crate::__reexport_tracing::Level::WARN, $($arg)*);
+    }}
+}
+
+/// Generate an `INFO` telemetry `Event`
+///
+/// ```rust
+/// use fuel_telemetry::prelude::*;
+///
+/// info_telemetry!("This info event will be sent to InfluxDB");
+/// ```
+#[macro_export]
+macro_rules! info_telemetry {
+    ($($arg:tt)*) => {{
+        span_telemetry!($crate::__reexport_tracing::Level::INFO, $($arg)*);
+    }}
+}
+
+/// Generate a `DEBUG` telemetry `Event`
+///
+/// ```rust
+/// use fuel_telemetry::prelude::*;
+///
+/// debug_telemetry!("This debug event will be sent to InfluxDB");
+/// ```
+#[macro_export]
+macro_rules! debug_telemetry {
+    ($($arg:tt)*) => {{
+        span_telemetry!($crate::__reexport_tracing::Level::DEBUG, $($arg)*);
+    }}
+}
+
+/// Generate a `TRACE` telemetry `Event`
+///
+/// ```rust
+/// use fuel_telemetry::prelude::*;
+///
+/// trace_telemetry!("This trace event will be sent to InfluxDB");
+/// ```
+#[macro_export]
+macro_rules! trace_telemetry {
+    ($($arg:tt)*) => {{
+        span_telemetry!($crate::__reexport_tracing::Level::TRACE, $($arg)*);
+    }}
+}
+
+/// Helper function to get the current process' binary filename
+pub fn get_process_name() -> String {
+    let mut exe_name = String::from("unknown");
+
+    if let Ok(exe) = current_exe() {
+        if let Some(name) = exe.file_name() {
+            if let Some(name_str) = name.to_str() {
+                exe_name = name_str.to_string().replace(':', "_");
+            }
+        }
+    }
+
+    exe_name
+}
+
+/// Enforce a singleton by taking an advisory lock on a file
+///
+/// This function takes an advisory lock on a file, and if another process has
+/// already locked the file, it will exit the current process.
+pub(crate) fn enforce_singleton(filename: &Path) -> Result<Flock<File>> {
+    enforce_singleton_with_helpers(filename, &mut DefaultEnforceSingletonHelpers)
+}
+
+fn enforce_singleton_with_helpers(
+    filename: &Path,
+    helpers: &mut impl EnforceSingletonHelpers,
+) -> Result<Flock<File>> {
+    let lockfile = helpers.open(filename)?;
+
+    let lock = match helpers.lock(lockfile) {
+        Ok(lock) => lock,
+        Err((_, Errno::EWOULDBLOCK)) => {
+            // Silently exit as another process has already locked the file
+            helpers.exit(0);
+        }
+        Err((_, e)) => return Err(TelemetryError::from(e)),
+    };
+
+    Ok(lock)
+}
+
+trait EnforceSingletonHelpers {
+    fn open(&self, filename: &Path) -> std::result::Result<File, std::io::Error> {
+        OpenOptions::new().create(true).append(true).open(filename)
+    }
+
+    fn lock(&self, file: File) -> std::result::Result<Flock<File>, (File, Errno)> {
+        Flock::lock(file, FlockArg::LockExclusiveNonblock)
+    }
+
+    fn exit(&self, status: i32) -> ! {
+        exit(status)
+    }
+}
+
+struct DefaultEnforceSingletonHelpers;
+impl EnforceSingletonHelpers for DefaultEnforceSingletonHelpers {}
+
+/// Daemonise the current process
+///
+/// This function forks and has the parent immediately return. The forked off
+/// child then follows the common "double-fork" method of daemonising.
+pub(crate) fn daemonise(log_filename: &PathBuf) -> WatcherResult<Option<Pid>> {
+    let mut helpers = DefaultDaemoniseHelpers;
+    daemonise_with_helpers(log_filename, &mut helpers)
+}
+
+fn daemonise_with_helpers(
+    log_filename: &PathBuf,
+    helpers: &mut impl DaemoniseHelpers,
+) -> WatcherResult<Option<Pid>> {
+    // All errors before the first fork() are recoverable from the caller,
+    // meaning that the error occured within the same process and should be
+    // ignored by the caller so that it can continue
+
+    helpers.flush(&mut stdout()).map_err(into_recoverable)?;
+    helpers.flush(&mut stderr()).map_err(into_recoverable)?;
+
+    let (read_fd, write_fd) = helpers.pipe().map_err(into_recoverable)?;
+
+    // Return if we are the parent
+    if helpers.fork().map_err(into_recoverable)?.is_parent() {
+        drop(write_fd);
+
+        let mut pid_bytes = [0u8; std::mem::size_of::<Pid>()];
+        helpers
+            .read_pipe(read_fd, &mut pid_bytes)
+            .map_err(into_recoverable)?;
+
+        return Ok(Some(Pid::from_raw(i32::from_ne_bytes(pid_bytes))));
+    };
+
+    drop(read_fd);
+
+    // From here on, we are no longer the original process, so the caller should
+    // treat errors as fatal. This means that on error the process should exit
+    // immediately as there should not be two identical flows of execution
+
+    // To prevent us from becoming a zombie when we die, we fork then kill the
+    // parent so that we are immediately inherited by init/systemd. Doing so, we
+    // are guaranteed to be reaped on exit.
+    //
+    // Also, doing this guarantees that we are not the group leader, which is
+    // required to create a new session (i.e setsid() will fail otherwise)
+    if helpers.fork().map_err(into_fatal)?.is_parent() {
+        drop(write_fd);
+        exit(0);
+    }
+
+    // Creating a new session means we won't receive signals to the original
+    // group or session (e.g. hitting CTRL-C to break a command pipeline)
+    helpers.setsid().map_err(into_fatal)?;
+
+    // As session leader, we now fork then follow the child again to guarantee
+    // we cannot re-acquire a terminal
+    if helpers.fork().map_err(into_fatal)?.is_parent() {
+        drop(write_fd);
+        exit(0);
+    }
+
+    let pid = getpid();
+    helpers.write_pipe(write_fd, pid).map_err(into_fatal)?;
+
+    // Setup stdio to write errors to the logfile while discarding any IO to
+    // the controlling terminal
+    let fuelup_tmp = helpers
+        .telemetry_config()
+        .map_err(into_fatal)?
+        .fuelup_tmp
+        .clone();
+
+    helpers.setup_stdio(
+        Path::new(&fuelup_tmp)
+            .join(log_filename)
+            .to_str()
+            .ok_or(TelemetryError::InvalidLogFile(
+                fuelup_tmp.clone(),
+                log_filename.clone(),
+            ))
+            .map_err(into_fatal)?,
+    )?;
+
+    // The current working directory needs to be set to root so that we don't
+    // prevent any unmounting of the filesystem leading up to the directory we
+    // started in
+    helpers.chdir(Path::new("/")).map_err(into_fatal)?;
+
+    // We close all file descriptors since any currently opened were inherited
+    // from the parent process which we don't care about. Not doing so leaks
+    // open file descriptors which could lead to exhaustion.
+    let max_fd = helpers
+        .sysconf(SysconfVar::OPEN_MAX)
+        .map_err(into_fatal)?
+        .unwrap_or(MIN_OPEN_MAX.into()) as i32;
+
+    for fd in FIRST_NON_STDIO_FD..=max_fd {
+        match helpers.close(fd) {
+            Ok(()) | Err(Errno::EBADF) => {}
+            Err(e) => Err(into_fatal(e))?,
+        }
+    }
+
+    // Clear the umask so that files we create aren't too permission-restricive
+    stat::umask(stat::Mode::empty());
+
+    Ok(None)
+}
+
+trait DaemoniseHelpers {
+    fn flush<T: Write + std::os::fd::AsRawFd>(
+        &mut self,
+        stream: &mut T,
+    ) -> std::result::Result<(), std::io::Error> {
+        stream.flush()
+    }
+
+    fn pipe(&mut self) -> nix::Result<(OwnedFd, OwnedFd)> {
+        pipe()
+    }
+
+    fn read_pipe(&mut self, read_fd: OwnedFd, pid_bytes: &mut [u8]) -> nix::Result<usize> {
+        read(read_fd.as_raw_fd(), pid_bytes)
+    }
+
+    fn fork(&mut self) -> nix::Result<ForkResult> {
+        unsafe { fork() }
+    }
+
+    fn setsid(&self) -> nix::Result<Pid> {
+        setsid()
+    }
+
+    fn write_pipe(&mut self, write_fd: OwnedFd, pid: Pid) -> nix::Result<usize> {
+        write(write_fd, &pid.as_raw().to_ne_bytes())
+    }
+
+    fn telemetry_config(&mut self) -> Result<&'static TelemetryConfig> {
+        telemetry_config()
+    }
+
+    fn setup_stdio(&self, log_filename: &str) -> std::result::Result<(), TelemetryError> {
+        setup_stdio(log_filename)
+    }
+
+    fn chdir(&self, path: &Path) -> nix::Result<()> {
+        chdir(path)
+    }
+
+    fn sysconf(&self, var: SysconfVar) -> nix::Result<Option<c_long>> {
+        sysconf(var)
+    }
+
+    fn close(&self, fd: c_int) -> nix::Result<()> {
+        close(fd)
+    }
+}
+
+struct DefaultDaemoniseHelpers;
+impl DaemoniseHelpers for DefaultDaemoniseHelpers {}
+
+trait SetupStdioHelpers {
+    fn create_append(&self, log_filename: &str) -> std::result::Result<File, std::io::Error> {
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_filename)
+    }
+
+    fn dup2(&mut self, fd: c_int, fd2: c_int) -> std::result::Result<c_int, nix::errno::Errno> {
+        dup2(fd, fd2)
+    }
+
+    fn read_write(&self, path: &str) -> std::result::Result<File, std::io::Error> {
+        OpenOptions::new().read(true).write(true).open(path)
+    }
+}
+
+struct DefaultSetupStdioHelpers;
+impl SetupStdioHelpers for DefaultSetupStdioHelpers {}
+
+/// Setup stdio for the process
+///
+/// This function redirects stderr to its logfile while discarding any IO to the
+/// controlling terminal.
+pub(crate) fn setup_stdio(log_filename: &str) -> std::result::Result<(), TelemetryError> {
+    let mut helpers = DefaultSetupStdioHelpers;
+    setup_stdio_with_helpers(log_filename, &mut helpers)
+}
+
+fn setup_stdio_with_helpers(
+    log_filename: &str,
+    helpers: &mut impl SetupStdioHelpers,
+) -> std::result::Result<(), TelemetryError> {
+    let log_file = helpers.create_append(log_filename)?;
+
+    // Redirect stderr to the logfile
+    helpers.dup2(log_file.as_raw_fd(), 2)?;
+
+    // Get a filehandle to /dev/null
+    let dev_null = helpers.read_write("/dev/null")?;
+
+    // Redirect stdin, stdout to /dev/null
+    helpers.dup2(dev_null.as_raw_fd(), 0)?;
+    helpers.dup2(dev_null.as_raw_fd(), 1)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn setup_fuelup_home() {
+    let tmp_dir = std::env::temp_dir().join(format!("fuelup-test-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp_dir).unwrap();
+    std::env::set_var("FUELUP_HOME", tmp_dir.to_str().unwrap());
+}
+
+#[cfg(test)]
+mod env_setting {
+    use super::*;
+    use std::env::set_var;
+
+    #[test]
+    fn unset() {
+        let env_setting = EnvSetting::new("does_not_exist", "default_value");
+        assert_eq!(env_setting.get(), "default_value");
+    }
+
+    #[test]
+    fn set() {
+        set_var("existing_variable", "existing_value");
+
+        let env_setting = EnvSetting::new("existing_variable", "default_value");
+        assert_eq!(env_setting.get(), "existing_value");
+    }
+}
+
+#[cfg(test)]
+mod telemetry_config {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+    use std::{env::set_var, path::Path};
+
+    rusty_fork_test! {
+        #[test]
+        fn fuelup_all_unset() {
+            let telemetry_config = telemetry_config().unwrap();
+            let fuelup_home = home_dir().unwrap();
+
+            assert_eq!(
+                telemetry_config.fuelup_tmp,
+                fuelup_home.join(".fuelup/tmp").to_str().unwrap()
+            );
+
+            assert_eq!(
+                telemetry_config.fuelup_log,
+                fuelup_home.join(".fuelup/log").to_str().unwrap()
+            );
+
+            assert!(Path::new(&telemetry_config.fuelup_tmp).is_dir());
+            assert!(Path::new(&telemetry_config.fuelup_log).is_dir());
+        }
+
+        #[test]
+        fn fuelup_home_set() {
+            setup_fuelup_home();
+
+            let tempdir = var("FUELUP_HOME").unwrap();
+            let telemetry_config = telemetry_config().unwrap();
+
+            assert_eq!(telemetry_config.fuelup_tmp, format!("{}/tmp", tempdir));
+            assert_eq!(telemetry_config.fuelup_log, format!("{}/log", tempdir));
+
+            assert!(Path::new(&telemetry_config.fuelup_tmp).is_dir());
+            assert!(Path::new(&telemetry_config.fuelup_log).is_dir());
+        }
+
+        #[test]
+        fn fuelup_tmp_set() {
+            let tmpdir = std::env::temp_dir().join(format!("fuelup-test-{}", uuid::Uuid::new_v4()));
+            set_var("FUELUP_TMP", tmpdir.to_str().unwrap());
+            std::fs::create_dir_all(&tmpdir).unwrap();
+
+            let telemetry_config = telemetry_config().unwrap();
+
+            assert_eq!(telemetry_config.fuelup_tmp, tmpdir.to_str().unwrap());
+
+            assert_eq!(
+                telemetry_config.fuelup_log,
+                home_dir().unwrap().join(".fuelup/log").to_str().unwrap()
+            );
+
+            assert!(Path::new(&telemetry_config.fuelup_tmp).is_dir());
+            assert!(Path::new(&telemetry_config.fuelup_log).is_dir());
+        }
+
+        #[test]
+        fn fuelup_log_set() {
+            let tmpdir = std::env::temp_dir().join(format!("fuelup-test-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&tmpdir).unwrap();
+            set_var("FUELUP_LOG", tmpdir.to_str().unwrap());
+
+            let telemetry_config = telemetry_config().unwrap();
+
+            assert_eq!(
+                telemetry_config.fuelup_tmp,
+                home_dir().unwrap().join(".fuelup/tmp").to_str().unwrap()
+            );
+
+            assert_eq!(telemetry_config.fuelup_log, tmpdir.to_str().unwrap());
+
+            assert!(Path::new(&telemetry_config.fuelup_tmp).is_dir());
+            assert!(Path::new(&telemetry_config.fuelup_log).is_dir());
+        }
+    }
+}
+
+#[cfg(test)]
+mod enforce_singleton {
+    use super::*;
+    use nix::unistd::ForkResult;
+    use rusty_fork::rusty_fork_test;
+    use std::os::fd::OwnedFd;
+
+    fn setup_lockfile() -> PathBuf {
+        let lockfile = format!("{}/test.lock", telemetry_config().unwrap().fuelup_tmp);
+
+        File::create(&lockfile).unwrap();
+        PathBuf::from(lockfile)
+    }
+
+    rusty_fork_test! {
+        #[test]
+        fn lockfile_open_failed() {
+            struct LockfileOpenFailed;
+
+            impl EnforceSingletonHelpers for LockfileOpenFailed {
+                fn open(&self, _filename: &Path) -> std::result::Result<File, std::io::Error> {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "Mock error",
+                    ))
+                }
+            }
+
+            assert_eq!(
+                enforce_singleton_with_helpers(Path::new("test.lock"), &mut LockfileOpenFailed)
+                    .err(),
+                Some(TelemetryError::IO("Mock error".to_string()))
+            );
+        }
+
+        #[test]
+        fn flock_ewouldblock() {
+            setup_fuelup_home();
+            let lockfile = setup_lockfile();
+
+            struct FlockEWouldblock {
+                write_fd: OwnedFd,
+            }
+
+            impl EnforceSingletonHelpers for FlockEWouldblock {
+                fn lock(&self, file: File) -> std::result::Result<Flock<File>, (File, Errno)> {
+                    Err((file, Errno::EWOULDBLOCK))
+                }
+
+                fn exit(&self, _status: i32) -> ! {
+                    // Test we exited at the expected code path
+                    let pid = getpid();
+                    write(&self.write_fd, &pid.as_raw().to_ne_bytes()).unwrap();
+
+                    exit(0);
+                }
+            }
+
+            let (read_fd, write_fd) = pipe().unwrap();
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    drop(write_fd);
+
+                    let mut pid_bytes = [0u8; std::mem::size_of::<Pid>()];
+                    read(read_fd.as_raw_fd(), &mut pid_bytes).unwrap();
+
+                    assert_eq!(pid_bytes, child.as_raw().to_ne_bytes());
+                }
+                ForkResult::Child => {
+                    drop(read_fd);
+
+                    let mut flock_ewouldblock = FlockEWouldblock { write_fd };
+
+                    enforce_singleton_with_helpers(&lockfile, &mut flock_ewouldblock).unwrap();
+
+                    // Fallback exit, which rusty_fork will catch
+                    exit(99);
+                }
+            }
+        }
+
+        #[test]
+        fn flock_other_error() {
+            setup_fuelup_home();
+            let lockfile = setup_lockfile();
+
+            struct FlockOtherError;
+
+            impl EnforceSingletonHelpers for FlockOtherError {
+                fn lock(&self, file: File) -> std::result::Result<Flock<File>, (File, Errno)> {
+                    Err((file, Errno::EOWNERDEAD))
+                }
+            }
+
+            let result = enforce_singleton_with_helpers(&lockfile, &mut FlockOtherError);
+
+            let expected = TelemetryError::Nix(Errno::EOWNERDEAD.to_string());
+            assert_eq!(result.err(), Some(expected));
+        }
+    }
+}
+
+#[cfg(test)]
+mod daemonise {
+    use super::*;
+    use nix::{
+        errno::Errno,
+        sys::wait::{waitpid, WaitStatus},
+        unistd::ForkResult,
+    };
+    use rusty_fork::rusty_fork_test;
+    use std::io::{Error, ErrorKind, Result, Write};
+
+    rusty_fork_test! {
+        #[test]
+        fn stdout_flush_failed() {
+            setup_fuelup_home();
+
+            struct StdoutFlushFailed;
+
+            impl DaemoniseHelpers for StdoutFlushFailed {
+                fn flush<T: Write + std::os::fd::AsRawFd>(&mut self, stream: &mut T) -> Result<()> {
+                    assert_eq!(stream.as_raw_fd(), 1);
+                    Err(Error::new(ErrorKind::Other, "Error flushing stdout"))
+                }
+            }
+
+            let result = daemonise_with_helpers(&PathBuf::from("test.log"), &mut StdoutFlushFailed);
+            assert!(matches!(result, Err(WatcherError::Recoverable(_))));
+        }
+
+        #[test]
+        fn stderr_flush_failed() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct StderrFlushFailed {
+                call_counter: usize,
+            }
+
+            impl DaemoniseHelpers for StderrFlushFailed {
+                fn flush<T: Write + std::os::fd::AsRawFd>(&mut self, stream: &mut T) -> Result<()> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 1 {
+                        Ok(())
+                    } else {
+                        assert_eq!(stream.as_raw_fd(), 2);
+                        Err(Error::new(ErrorKind::Other, "Error flushing stderr"))
+                    }
+                }
+            }
+
+            let result = daemonise_with_helpers(
+                &PathBuf::from("test.log"),
+                &mut StderrFlushFailed::default(),
+            );
+
+            assert!(matches!(result, Err(WatcherError::Recoverable(_))));
+        }
+
+        #[test]
+        fn pipe_failed() {
+            setup_fuelup_home();
+
+            struct PipeFailed;
+
+            impl DaemoniseHelpers for PipeFailed {
+                fn pipe(&mut self) -> nix::Result<(OwnedFd, OwnedFd)> {
+                    Err(Errno::EOWNERDEAD)
+                }
+            }
+
+            let result = daemonise_with_helpers(&PathBuf::from("test.log"), &mut PipeFailed);
+            let expected_error = TelemetryError::Nix(Errno::EOWNERDEAD.to_string());
+
+            assert_eq!(
+                result.err(),
+                Some(WatcherError::Recoverable(expected_error))
+            );
+        }
+
+        #[test]
+        fn first_fork_failed() {
+            setup_fuelup_home();
+
+            struct FirstForkFailed;
+
+            impl DaemoniseHelpers for FirstForkFailed {
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    Err(Errno::EOWNERDEAD)
+                }
+            }
+
+            assert_eq!(
+                daemonise_with_helpers(&PathBuf::from("test.log"), &mut FirstForkFailed),
+                Err(WatcherError::Recoverable(TelemetryError::Nix(
+                    Errno::EOWNERDEAD.to_string()
+                )))
+            );
+        }
+
+        #[test]
+        fn first_fork_is_parent() {
+            setup_fuelup_home();
+
+            struct FirstForkIsParent;
+
+            impl DaemoniseHelpers for FirstForkIsParent {
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    Ok(ForkResult::Parent {
+                        child: Pid::from_raw(1),
+                    })
+                }
+            }
+
+            let result = daemonise_with_helpers(&PathBuf::from("test.log"), &mut FirstForkIsParent);
+            assert!(matches!(result, Ok(Some(_))));
+        }
+
+        #[test]
+        fn second_fork_failed() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct SecondForkFailed {
+                call_counter: usize,
+            }
+
+            impl DaemoniseHelpers for SecondForkFailed {
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 2 {
+                        Err(Errno::EOWNERDEAD)
+                    } else {
+                        Ok(ForkResult::Child)
+                    }
+                }
+            }
+
+            let result = daemonise_with_helpers(
+                &PathBuf::from("test.log"),
+                &mut SecondForkFailed::default(),
+            );
+
+            assert!(matches!(result, Err(WatcherError::Fatal(_))));
+        }
+
+        #[test]
+        fn second_fork_is_parent() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct SecondForkIsParent {
+                call_counter: usize,
+            }
+
+            impl DaemoniseHelpers for SecondForkIsParent {
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 2 {
+                        Ok(ForkResult::Parent {
+                            child: Pid::from_raw(1),
+                        })
+                    } else {
+                        Ok(ForkResult::Child)
+                    }
+                }
+            }
+
+            // We ourselves fork so that we can `waitpid` on the function
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => match waitpid(child, None).unwrap() {
+                    WaitStatus::Exited(_, code) => {
+                        assert_eq!(code, 0);
+                    }
+                    _ => panic!("Child did not exit normally"),
+                },
+                ForkResult::Child => {
+                    let _ = daemonise_with_helpers(
+                        &PathBuf::from("test.log"),
+                        &mut SecondForkIsParent::default(),
+                    );
+
+                    // Fallback exit
+                    exit(99);
+                }
+            }
+        }
+
+        #[test]
+        fn setsid_failed() {
+            setup_fuelup_home();
+
+            struct SetsidFailed;
+
+            impl DaemoniseHelpers for SetsidFailed {
+                fn setsid(&self) -> nix::Result<Pid> {
+                    Err(Errno::EOWNERDEAD)
+                }
+
+                // Need to become the child so we don't return as the parent
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    Ok(ForkResult::Child)
+                }
+            }
+
+            let result = daemonise_with_helpers(&PathBuf::from("test.log"), &mut SetsidFailed);
+
+            let expected_error = TelemetryError::Nix(Errno::EOWNERDEAD.to_string());
+            assert_eq!(result.err(), Some(WatcherError::Fatal(expected_error)));
+        }
+
+        #[test]
+        fn third_fork_failed() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct ThirdForkFailed {
+                call_counter: usize,
+            }
+
+            impl DaemoniseHelpers for ThirdForkFailed {
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 3 {
+                        Err(Errno::EOWNERDEAD)
+                    } else {
+                        Ok(ForkResult::Child)
+                    }
+                }
+            }
+
+            let result =
+                daemonise_with_helpers(&PathBuf::from("test.log"), &mut ThirdForkFailed::default());
+
+            let expected_error = TelemetryError::Nix(Errno::EOWNERDEAD.to_string());
+            assert_eq!(result.err(), Some(WatcherError::Fatal(expected_error)));
+        }
+
+        #[test]
+        fn third_fork_is_parent() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct ThirdForkIsParent {
+                call_counter: usize,
+            }
+
+            impl DaemoniseHelpers for ThirdForkIsParent {
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 3 {
+                        Ok(ForkResult::Parent {
+                            child: Pid::from_raw(1),
+                        })
+                    } else {
+                        Ok(ForkResult::Child)
+                    }
+                }
+            }
+
+            // We ourselves fork so that we can `waitpid` on the function
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => match waitpid(child, None).unwrap() {
+                    WaitStatus::Exited(_, code) => {
+                        assert_eq!(code, 0);
+                    }
+                    _ => panic!("Child did not exit normally"),
+                },
+                ForkResult::Child => {
+                    let _ = daemonise_with_helpers(
+                        &PathBuf::from("test.log"),
+                        &mut ThirdForkIsParent::default(),
+                    );
+
+                    // Fallback exit
+                    exit(99);
+                }
+            }
+        }
+
+        #[test]
+        fn write_pipe_failed() {
+            setup_fuelup_home();
+
+            struct WritePipeFailed;
+
+            impl DaemoniseHelpers for WritePipeFailed {
+                fn write_pipe(&mut self, _write_fd: OwnedFd, _pid: Pid) -> nix::Result<usize> {
+                    Err(Errno::EOWNERDEAD)
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    Ok(ForkResult::Child)
+                }
+            }
+
+            let result = daemonise_with_helpers(&PathBuf::from("test.log"), &mut WritePipeFailed);
+
+            let expected_error = TelemetryError::Nix(Errno::EOWNERDEAD.to_string());
+            assert_eq!(result.err(), Some(WatcherError::Fatal(expected_error)));
+        }
+
+        #[test]
+        fn telemetry_config_failed() {
+            setup_fuelup_home();
+
+            struct TelemetryConfigFailed;
+
+            impl DaemoniseHelpers for TelemetryConfigFailed {
+                fn telemetry_config(
+                    &mut self,
+                ) -> std::result::Result<&'static TelemetryConfig, errors::TelemetryError>
+                {
+                    Err(TelemetryError::Mock)
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) =
+                daemonise_with_helpers(&PathBuf::from("test.log"), &mut TelemetryConfigFailed)
+            {
+                assert_eq!(e, WatcherError::Fatal(TelemetryError::Mock));
+            }
+        }
+
+        #[test]
+        fn setup_stdio_failed() {
+            setup_fuelup_home();
+
+            struct SetupStdioFailed;
+
+            impl DaemoniseHelpers for SetupStdioFailed {
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Err(TelemetryError::IO("Error setting up stdio".to_string()))
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) =
+                daemonise_with_helpers(&PathBuf::from("test.log"), &mut SetupStdioFailed)
+            {
+                let expected_error = TelemetryError::IO("Error setting up stdio".to_string());
+                assert_eq!(e, WatcherError::Fatal(expected_error));
+            }
+        }
+
+        #[test]
+        fn join_failed() {
+            setup_fuelup_home();
+
+            struct JoinFailed;
+
+            impl DaemoniseHelpers for JoinFailed {
+                fn telemetry_config(
+                    &mut self,
+                ) -> std::result::Result<&'static TelemetryConfig, errors::TelemetryError>
+                {
+                    pub static _TELEMETRY_CONFIG: LazyLock<Result<TelemetryConfig>> =
+                        LazyLock::new(|| {
+                            Ok(TelemetryConfig {
+                                // Use invalid UTF-8 to trigger the error
+                                fuelup_tmp: unsafe { String::from_utf8_unchecked(vec![0xFF]) },
+                                fuelup_log: "".to_string(),
+                            })
+                        });
+
+                    _TELEMETRY_CONFIG.as_ref().map_err(|_| {
+                        TelemetryError::InvalidConfig("Error getting telemetry config".to_string())
+                    })
+                }
+
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Ok(())
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) = daemonise_with_helpers(&PathBuf::from("test.log"), &mut JoinFailed) {
+                assert!(matches!(
+                    e,
+                    WatcherError::Fatal(TelemetryError::InvalidLogFile(_, _))
+                ));
+            }
+        }
+
+        #[test]
+        fn chdir_failed() {
+            setup_fuelup_home();
+
+            struct ChdirFailed;
+
+            impl DaemoniseHelpers for ChdirFailed {
+                fn chdir(&self, _path: &Path) -> nix::Result<()> {
+                    Err(Errno::EOWNERDEAD)
+                }
+
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Ok(())
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) = daemonise_with_helpers(&PathBuf::from("test.log"), &mut ChdirFailed) {
+                assert_eq!(
+                    e,
+                    WatcherError::Fatal(TelemetryError::Nix(Errno::EOWNERDEAD.to_string()))
+                );
+            }
+        }
+
+        #[test]
+        fn sysconf_failed() {
+            setup_fuelup_home();
+
+            struct SysconfFailed;
+
+            impl DaemoniseHelpers for SysconfFailed {
+                fn sysconf(&self, _var: SysconfVar) -> nix::Result<Option<c_long>> {
+                    Err(Errno::EOWNERDEAD)
+                }
+
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Ok(())
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) = daemonise_with_helpers(&PathBuf::from("test.log"), &mut SysconfFailed) {
+                assert_eq!(
+                    e,
+                    WatcherError::Fatal(TelemetryError::Nix(Errno::EOWNERDEAD.to_string()))
+                );
+            }
+        }
+
+        #[test]
+        fn close_failed_with_ebadf() {
+            setup_fuelup_home();
+
+            struct CloseFailed;
+
+            impl DaemoniseHelpers for CloseFailed {
+                fn close(&self, _fd: c_int) -> nix::Result<()> {
+                    Err(Errno::EBADF)
+                }
+
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Ok(())
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) = daemonise_with_helpers(&PathBuf::from("test.log"), &mut CloseFailed) {
+                assert_eq!(
+                    e,
+                    WatcherError::Fatal(TelemetryError::Nix(Errno::EBADF.to_string()))
+                );
+            }
+        }
+
+        #[test]
+        fn close_failed_with_other_error() {
+            setup_fuelup_home();
+
+            struct CloseFailed;
+
+            impl DaemoniseHelpers for CloseFailed {
+                fn close(&self, _fd: c_int) -> nix::Result<()> {
+                    Err(Errno::EOWNERDEAD)
+                }
+
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Ok(())
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            if let Err(e) = daemonise_with_helpers(&PathBuf::from("test.log"), &mut CloseFailed) {
+                assert_eq!(
+                    e,
+                    WatcherError::Fatal(TelemetryError::Nix(Errno::EOWNERDEAD.to_string()))
+                );
+            }
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            struct AOk;
+
+            impl DaemoniseHelpers for AOk {
+                fn setup_stdio(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<(), TelemetryError> {
+                    Ok(())
+                }
+
+                fn fork(&mut self) -> nix::Result<ForkResult> {
+                    // We want to continue as the child process, so flip the fork result
+                    // and return the original parent as the child
+                    let original_parent = getpid();
+
+                    match unsafe { fork() }.unwrap() {
+                        ForkResult::Parent { child: _child } => Ok(ForkResult::Child),
+                        ForkResult::Child => Ok(ForkResult::Parent {
+                            child: original_parent,
+                        }),
+                    }
+                }
+            }
+
+            let parent_pid = getpid();
+            let result = daemonise_with_helpers(&PathBuf::from("test.log"), &mut AOk);
+
+            // We only care about the point of view from the parent (with flipped fork result)
+            if getpid() == parent_pid {
+                assert_eq!(result, Ok(None));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod setup_stdio {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn create_append_failed() {
+            setup_fuelup_home();
+
+            struct CreateAppendFailed;
+
+            impl SetupStdioHelpers for CreateAppendFailed {
+                fn create_append(
+                    &self,
+                    _log_filename: &str,
+                ) -> std::result::Result<File, std::io::Error> {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "Error creating append",
+                    ))
+                }
+            }
+
+            let result = setup_stdio_with_helpers(
+                &format!("{}/test.log", telemetry_config().unwrap().fuelup_log),
+                &mut CreateAppendFailed,
+            );
+
+            assert!(matches!(result, Err(TelemetryError::IO(_))));
+        }
+
+        #[test]
+        fn first_dup2_failed() {
+            setup_fuelup_home();
+
+            struct FirstDup2Failed;
+
+            impl SetupStdioHelpers for FirstDup2Failed {
+                fn dup2(
+                    &mut self,
+                    _fd: c_int,
+                    fd2: c_int,
+                ) -> std::result::Result<c_int, nix::errno::Errno> {
+                    assert_eq!(fd2, 2);
+                    Err(nix::errno::Errno::EOWNERDEAD)
+                }
+            }
+
+            let result = setup_stdio_with_helpers(
+                &format!("{}/test.log", telemetry_config().unwrap().fuelup_log),
+                &mut FirstDup2Failed,
+            );
+
+            assert!(matches!(result, Err(TelemetryError::Nix(_))));
+        }
+
+        #[test]
+        fn read_write_failed() {
+            setup_fuelup_home();
+
+            struct ReadWriteFailed;
+
+            impl SetupStdioHelpers for ReadWriteFailed {
+                fn read_write(&self, _path: &str) -> std::result::Result<File, std::io::Error> {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "Error reading write",
+                    ))
+                }
+            }
+
+            let result = setup_stdio_with_helpers(
+                &format!("{}/test.log", telemetry_config().unwrap().fuelup_log),
+                &mut ReadWriteFailed,
+            );
+
+            assert!(matches!(result, Err(TelemetryError::IO(_))));
+        }
+
+        #[test]
+        fn second_dup2_failed() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct SecondDup2Failed {
+                call_counter: usize,
+            }
+
+            impl SetupStdioHelpers for SecondDup2Failed {
+                fn dup2(
+                    &mut self,
+                    _fd: c_int,
+                    fd2: c_int,
+                ) -> std::result::Result<c_int, nix::errno::Errno> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 2 {
+                        assert_eq!(fd2, 0);
+                        Err(nix::errno::Errno::EOWNERDEAD)
+                    } else {
+                        Ok(0)
+                    }
+                }
+            }
+
+            let result = setup_stdio_with_helpers(
+                &format!("{}/test.log", telemetry_config().unwrap().fuelup_log),
+                &mut SecondDup2Failed::default(),
+            );
+
+            assert!(matches!(result, Err(TelemetryError::Nix(_))));
+        }
+
+        #[test]
+        fn third_dup2_failed() {
+            setup_fuelup_home();
+
+            #[derive(Default)]
+            struct ThirdDup2Failed {
+                call_counter: usize,
+            }
+
+            impl SetupStdioHelpers for ThirdDup2Failed {
+                fn dup2(
+                    &mut self,
+                    _fd: c_int,
+                    fd2: c_int,
+                ) -> std::result::Result<c_int, nix::errno::Errno> {
+                    self.call_counter += 1;
+
+                    if self.call_counter == 3 {
+                        assert_eq!(fd2, 1);
+                        Err(nix::errno::Errno::EOWNERDEAD)
+                    } else {
+                        Ok(0)
+                    }
+                }
+            }
+
+            let result = setup_stdio_with_helpers(
+                &format!("{}/test.log", telemetry_config().unwrap().fuelup_log),
+                &mut ThirdDup2Failed::default(),
+            );
+
+            assert!(matches!(result, Err(TelemetryError::Nix(_))));
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            let result = setup_stdio_with_helpers(
+                &format!("{}/test.log", telemetry_config().unwrap().fuelup_log),
+                &mut DefaultSetupStdioHelpers,
+            );
+
+            assert!(matches!(result, Ok(())));
+        }
+    }
+}

--- a/src/process_watcher.rs
+++ b/src/process_watcher.rs
@@ -1,0 +1,1256 @@
+use crate::{
+    self as fuel_telemetry, daemonise,
+    errors::{into_recoverable, TelemetryError},
+    get_process_name, info_telemetry, span_telemetry, telemetry_config, telemetry_formatter,
+    EnvSetting, Result, WatcherResult,
+};
+use nix::{
+    sys::signal::kill,
+    unistd::{getpid, Pid as NixPid},
+};
+use std::{
+    env::{set_var, var},
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+    process::exit,
+    sync::{
+        atomic::{AtomicBool, AtomicI32, Ordering},
+        LazyLock,
+    },
+    thread::sleep,
+    time::{Duration, Instant},
+};
+use sysinfo::{Pid as SysinfoPid, ProcessRefreshKind, ProcessesToUpdate, System};
+use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
+
+//
+// Module config
+//
+
+const PROCESS_NAME: &str = "telemetry-process-watcher";
+const PROCESSWATCHER_CHECK_INTERVAL: &str = "1";
+const PROCESSWATCHER_MEASURE_INTERVAL: &str = "60";
+const TELEMETRY_PKG_NAME: &str = "process_watcher";
+
+struct ProcessWatcherConfig {
+    // The path to its logfile
+    logfile: PathBuf,
+    // The interval between checking if the process is still alive (in seconds)
+    check_interval: Duration,
+    // The interval between measuring process metrics (in seconds)
+    measure_interval: Duration,
+}
+
+fn config() -> Result<&'static ProcessWatcherConfig> {
+    static PROCESS_WATCHER_CONFIG: LazyLock<Result<ProcessWatcherConfig>> = LazyLock::new(|| {
+        let get_env = |key, default| EnvSetting::new(key, default).get();
+
+        let check_interval = get_env(
+            "PROCESSWATCHER_CHECK_INTERVAL",
+            PROCESSWATCHER_CHECK_INTERVAL,
+        )
+        .parse()
+        .map(Duration::from_secs)?;
+
+        let measure_interval = get_env(
+            "PROCESSWATCHER_MEASURE_INTERVAL",
+            PROCESSWATCHER_MEASURE_INTERVAL,
+        )
+        .parse()
+        .map(Duration::from_secs)?;
+
+        Ok(ProcessWatcherConfig {
+            check_interval,
+            measure_interval,
+            logfile: Path::new(&telemetry_config()?.fuelup_log)
+                .join(format!("{}.log", PROCESS_NAME)),
+        })
+    });
+
+    PROCESS_WATCHER_CONFIG
+        .as_ref()
+        .map_err(|e| TelemetryError::InvalidConfig(e.to_string()))
+}
+
+pub struct ProcessWatcher {
+    // The name of the process used as the "measurement" for InfluxDB
+    exe_name: String,
+
+    // The PID we are watching (Nix PID)
+    pid_to_watch_nix: NixPid,
+    // The PID we are watching (Sysinfo PID)
+    pid_to_watch_sysinfo: SysinfoPid,
+
+    // The timer for checking if the process is still alive
+    check_timer: Timer,
+    // The timer for measuring the process metrics
+    measure_timer: Timer,
+
+    // Max metrics values we've seen so far
+    resident_memory: u64,
+    virtual_memory: u64,
+    run_time: u64,
+    cpu_usage: f32,
+}
+
+// Prevent recursive calls to start()
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+/// The PID of the currently running `ProcessWatcher` daemon
+pub static PID: AtomicI32 = AtomicI32::new(0);
+
+impl ProcessWatcher {
+    pub fn new() -> Result<Self> {
+        Self::new_with_pid(getpid())
+    }
+
+    pub fn new_with_pid(pid_to_watch: NixPid) -> Result<Self> {
+        Ok(Self {
+            exe_name: get_process_name(),
+
+            pid_to_watch_nix: pid_to_watch,
+            pid_to_watch_sysinfo: SysinfoPid::from(pid_to_watch.as_raw() as usize),
+
+            check_timer: Timer::new(config()?.check_interval),
+            measure_timer: Timer::new(config()?.measure_interval),
+
+            resident_memory: 0,
+            virtual_memory: 0,
+            run_time: 0,
+            cpu_usage: 0.0,
+        })
+    }
+
+    pub fn start(&mut self) -> WatcherResult<()> {
+        self.start_with_helpers(&DefaultStartHelpers)
+    }
+
+    fn start_with_helpers(&mut self, helpers: &impl StartHelpers) -> WatcherResult<()> {
+        if var("FUELUP_NO_TELEMETRY").is_ok() {
+            // If telemetry is disabled, immediately return
+            return Ok(());
+        }
+
+        let logfile = &config().map_err(into_recoverable)?.logfile;
+
+        if STARTED.load(Ordering::Relaxed) {
+            return Ok(());
+        } else {
+            STARTED.store(true, Ordering::Relaxed);
+        }
+
+        match helpers.daemonise(logfile) {
+            Ok(Some(pid)) => {
+                // We are the parent, so record the PID then immediately return
+                PID.store(pid.as_raw(), Ordering::Relaxed);
+                return Ok(());
+            }
+            Err(e) => {
+                // Couldn't daemonise, so clear globals before returning the error
+                STARTED.store(false, Ordering::Relaxed);
+                PID.store(0, Ordering::Relaxed);
+                return Err(e);
+            }
+            Ok(None) => {
+                // We are the child process, so continue as the `ProcessWatcher`
+                PID.store(getpid().as_raw(), Ordering::Relaxed);
+            }
+        }
+
+        set_var("TELEMETRY_PKG_NAME", TELEMETRY_PKG_NAME);
+        let (telemetry_layer, _guard) = helpers.new_fuel_telemetry()?;
+        tracing_subscriber::registry().with(telemetry_layer).init();
+
+        // Take a measurement now before going to sleep
+        helpers.measure_process(self);
+
+        while helpers.process_is_alive(self) {
+            self.check_timer.last_measure = helpers.get_instant_now();
+
+            if helpers.measure_timer_is_ready(self) {
+                helpers.measure_process(self);
+            }
+
+            let next_ready_timer =
+                helpers.get_next_ready_timer(&[&self.check_timer, &self.measure_timer]);
+
+            helpers.sleep(next_ready_timer.duration_until_ready());
+        }
+
+        // Record metrics one last time
+        helpers.record_metrics(self, false);
+
+        helpers.exit(0);
+    }
+
+    /// Last resort logging of errors, only to be used by the caller when there
+    /// is no other way to report an error.
+    pub fn log_error(message: &str) -> Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&config()?.logfile)?;
+
+        Ok(writeln!(file, "{}", message)?)
+    }
+}
+
+trait StartHelpers {
+    fn daemonise(&self, logfile: &PathBuf) -> WatcherResult<Option<NixPid>> {
+        daemonise(logfile)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn new_fuel_telemetry(
+        &self,
+    ) -> Result<(
+        tracing_subscriber::filter::Filtered<
+            tracing_subscriber::fmt::Layer<
+                tracing_subscriber::Registry,
+                tracing_subscriber::fmt::format::DefaultFields,
+                telemetry_formatter::TelemetryFormatter,
+                tracing_appender::non_blocking::NonBlocking,
+            >,
+            tracing_subscriber::EnvFilter,
+            tracing_subscriber::Registry,
+        >,
+        tracing_appender::non_blocking::WorkerGuard,
+    )> {
+        fuel_telemetry::new!()
+    }
+
+    fn measure_process(&self, process_watcher: &mut ProcessWatcher) {
+        let mut sysinfo = System::new();
+
+        // Need to refresh twice with delay in between so that there are enough
+        // data points for "cpu_usage". See `sysinfo` docs for more details.
+        sysinfo.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[process_watcher.pid_to_watch_sysinfo]),
+            true,
+            ProcessRefreshKind::nothing().with_memory().with_cpu(),
+        );
+
+        sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+
+        sysinfo.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[process_watcher.pid_to_watch_sysinfo]),
+            true,
+            ProcessRefreshKind::nothing().with_memory().with_cpu(),
+        );
+
+        let Some(process) = sysinfo.process(process_watcher.pid_to_watch_sysinfo) else {
+            // Process has likely exited, so return and deal with it at a higher level
+            return;
+        };
+
+        // Store the metrics so we can find the max values for the entire run
+        let residential_memory = process.memory();
+        let virtual_memory = process.virtual_memory();
+        let run_time = process.run_time();
+        let cpu_usage = process.cpu_usage();
+
+        process_watcher.resident_memory = process_watcher.resident_memory.max(residential_memory);
+        process_watcher.virtual_memory = process_watcher.virtual_memory.max(virtual_memory);
+        process_watcher.run_time = process_watcher.run_time.max(run_time);
+        process_watcher.cpu_usage = process_watcher.cpu_usage.max(cpu_usage);
+
+        // Record the metrics to disk
+        self.record_metrics(process_watcher, true);
+
+        // Restart the measure timer
+        process_watcher.measure_timer.last_measure = Instant::now();
+    }
+
+    fn process_is_alive(&self, process_watcher: &ProcessWatcher) -> bool {
+        kill(process_watcher.pid_to_watch_nix, None).is_ok()
+    }
+
+    fn get_instant_now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn measure_timer_is_ready(&self, process_watcher: &ProcessWatcher) -> bool {
+        process_watcher.measure_timer.is_ready()
+    }
+
+    fn get_next_ready_timer<'a>(&self, timers: &[&'a Timer]) -> &'a Timer {
+        Timer::next_ready_timer(timers)
+    }
+
+    fn sleep(&self, duration: Duration) {
+        sleep(duration)
+    }
+
+    fn record_metrics(&self, process_watcher: &ProcessWatcher, running: bool) {
+        info_telemetry!(
+            exe_name = process_watcher.exe_name,
+            running,
+            run_time = process_watcher.run_time,
+            cpu_usage = f64::from(process_watcher.cpu_usage),
+            resident_memory = process_watcher.resident_memory,
+            virtual_memory = process_watcher.virtual_memory,
+        );
+    }
+
+    fn exit(&self, code: i32) -> ! {
+        exit(code)
+    }
+}
+
+#[derive(Default, Clone)]
+struct DefaultStartHelpers;
+impl StartHelpers for DefaultStartHelpers {}
+
+/// A helper struct to manage timers used in the `ProcessWatcher`
+struct Timer {
+    last_measure: Instant,
+    interval: Duration,
+}
+
+// A zero duration timer used as a default value
+static ZERO_TIMER: LazyLock<Timer> = LazyLock::new(|| Timer {
+    last_measure: Instant::now(),
+    interval: Duration::from_secs(0),
+});
+
+impl Timer {
+    fn new(interval: Duration) -> Self {
+        Self {
+            last_measure: Instant::now(),
+            interval,
+        }
+    }
+
+    /// Find the timer in the haystack that's going to go off next
+    fn next_ready_timer<'a>(timers: &[&'a Timer]) -> &'a Timer {
+        timers
+            .iter()
+            .min_by_key(|t| t.duration_until_ready())
+            .copied()
+            .unwrap_or(&ZERO_TIMER)
+    }
+
+    /// Check if the timer is ready to go off
+    fn is_ready(&self) -> bool {
+        Instant::now().duration_since(self.last_measure) >= self.interval
+    }
+
+    /// How long until the timer will go off
+    fn duration_until_ready(&self) -> Duration {
+        self.interval
+            .saturating_sub(Instant::now().duration_since(self.last_measure))
+    }
+}
+
+#[cfg(test)]
+mod config {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use dirs::home_dir;
+    use rusty_fork::rusty_fork_test;
+    use std::env::set_var;
+
+    rusty_fork_test! {
+        #[test]
+        fn all_unset() {
+            let config = config().unwrap();
+
+            assert_eq!(
+                config.check_interval,
+                Duration::from_secs(PROCESSWATCHER_CHECK_INTERVAL.parse().unwrap())
+            );
+
+            assert_eq!(
+                config.measure_interval,
+                Duration::from_secs(PROCESSWATCHER_MEASURE_INTERVAL.parse().unwrap())
+            );
+
+            assert_eq!(
+                config.logfile,
+                PathBuf::from(
+                    &home_dir()
+                        .unwrap()
+                        .join(format!(".fuelup/log/{}.log", PROCESS_NAME))
+                )
+            );
+        }
+
+        #[test]
+        fn process_watcher_check_interval_invalid() {
+            set_var("PROCESSWATCHER_CHECK_INTERVAL", "invalid interval");
+
+            assert_eq!(
+                config().err(),
+                Some(TelemetryError::InvalidConfig(
+                    TelemetryError::Parse("invalid digit found in string".to_string()).into()
+                ))
+            );
+        }
+
+        #[test]
+        fn process_watcher_check_interval_set() {
+            set_var("PROCESSWATCHER_CHECK_INTERVAL", "2222");
+            assert_eq!(config().unwrap().check_interval, Duration::from_secs(2222));
+        }
+
+        #[test]
+        fn process_watcher_measure_interval_invalid() {
+            set_var("PROCESSWATCHER_MEASURE_INTERVAL", "invalid interval");
+            assert_eq!(
+                config().err(),
+                Some(TelemetryError::InvalidConfig(
+                    TelemetryError::Parse("invalid digit found in string".to_string()).into()
+                ))
+            );
+        }
+
+        #[test]
+        fn process_watcher_measure_interval_set() {
+            set_var("PROCESSWATCHER_MEASURE_INTERVAL", "2222");
+            assert_eq!(
+                config().unwrap().measure_interval,
+                Duration::from_secs(2222)
+            );
+        }
+
+        #[test]
+        fn all_set() {
+            setup_fuelup_home();
+            let fuelup_home = var("FUELUP_HOME").unwrap();
+
+            set_var("PROCESSWATCHER_CHECK_INTERVAL", "2222");
+            set_var("PROCESSWATCHER_MEASURE_INTERVAL", "3333");
+
+            let config = config().unwrap();
+
+            assert_eq!(config.check_interval, Duration::from_secs(2222));
+            assert_eq!(config.measure_interval, Duration::from_secs(3333));
+
+            assert_eq!(
+                config.logfile,
+                PathBuf::from(&fuelup_home).join(format!("log/{}.log", PROCESS_NAME))
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod new {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn new() {
+            setup_fuelup_home();
+
+            let process_watcher = ProcessWatcher::new().unwrap();
+
+            assert_eq!(process_watcher.exe_name, get_process_name());
+
+            assert_eq!(process_watcher.pid_to_watch_nix, getpid());
+            assert_eq!(
+                process_watcher.pid_to_watch_sysinfo,
+                SysinfoPid::from(getpid().as_raw() as usize)
+            );
+
+            assert_eq!(process_watcher.check_timer.interval, Duration::from_secs(1));
+            assert_eq!(
+                process_watcher.measure_timer.interval,
+                Duration::from_secs(60)
+            );
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+        }
+
+        #[test]
+        fn new_with_pid() {
+            setup_fuelup_home();
+
+            let process_watcher = ProcessWatcher::new_with_pid(NixPid::from_raw(1)).unwrap();
+
+            assert_eq!(process_watcher.exe_name, get_process_name());
+
+            assert_eq!(process_watcher.pid_to_watch_nix, NixPid::from_raw(1));
+            assert_eq!(process_watcher.pid_to_watch_sysinfo, SysinfoPid::from(1));
+
+            assert_eq!(process_watcher.check_timer.interval, Duration::from_secs(1));
+            assert_eq!(
+                process_watcher.measure_timer.interval,
+                Duration::from_secs(60)
+            );
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+        }
+    }
+}
+
+// The following tests verify that the expected paths are taken on error. The
+// testing of the values themselves is handled in the modules after this one.
+
+#[cfg(test)]
+mod start {
+    use super::*;
+    use crate::{errors::into_fatal, setup_fuelup_home, WatcherError};
+    use nix::{
+        sys::wait::{waitpid, WaitStatus},
+        unistd::{dup2, fork, pipe, ForkResult},
+    };
+    use rusty_fork::rusty_fork_test;
+    use std::{
+        env::set_var,
+        fs::File,
+        io::{stdout, Read, Write},
+        os::fd::{AsRawFd, FromRawFd, IntoRawFd},
+        sync::Arc,
+    };
+
+    rusty_fork_test! {
+        #[test]
+        fn opted_out_is_true() {
+            setup_fuelup_home();
+
+            set_var("FUELUP_NO_TELEMETRY", "true");
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+            let result = process_watcher.start();
+
+            assert_eq!(result, Ok(()));
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+        }
+
+        #[test]
+        fn opted_out_is_empty() {
+            setup_fuelup_home();
+
+            // Even though it's empty, we only care if it's set
+            set_var("FUELUP_NO_TELEMETRY", "");
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+            let result = process_watcher.start();
+
+            assert_eq!(result, Ok(()));
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+        }
+
+        #[test]
+        fn already_started() {
+            setup_fuelup_home();
+
+            STARTED.store(true, Ordering::Relaxed);
+            PID.store(1, Ordering::Relaxed);
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+            let result = process_watcher.start();
+
+            assert_eq!(result, Ok(()));
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1);
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+
+            // Try to start it again to test re-entrance
+            let result = process_watcher.start();
+
+            assert_eq!(result, Ok(()));
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1);
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+        }
+
+        #[test]
+        fn daemonise_failed() {
+            setup_fuelup_home();
+
+            struct DaemoniseFailed;
+
+            impl StartHelpers for DaemoniseFailed {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<NixPid>> {
+                    Err(into_fatal(TelemetryError::Mock))
+                }
+            }
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+            let result = process_watcher.start_with_helpers(&DaemoniseFailed);
+
+            assert_eq!(
+                result.err(),
+                Some(WatcherError::Fatal(TelemetryError::Mock))
+            );
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn daemonise_is_parent() {
+            setup_fuelup_home();
+
+            struct DaemoniseIsParent;
+
+            impl StartHelpers for DaemoniseIsParent {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<NixPid>> {
+                    Ok(Some(NixPid::from_raw(1337)))
+                }
+            }
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+            let result = process_watcher.start_with_helpers(&DaemoniseIsParent);
+
+            assert_eq!(result, Ok(()));
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1337);
+        }
+
+        #[test]
+        fn new_fuel_telemetry_failed() {
+            setup_fuelup_home();
+
+            struct NewFuelTelemetryFailed;
+
+            impl StartHelpers for NewFuelTelemetryFailed {
+                fn new_fuel_telemetry(
+                    &self,
+                ) -> Result<(
+                    tracing_subscriber::filter::Filtered<
+                        tracing_subscriber::fmt::Layer<
+                            tracing_subscriber::Registry,
+                            tracing_subscriber::fmt::format::DefaultFields,
+                            telemetry_formatter::TelemetryFormatter,
+                            tracing_appender::non_blocking::NonBlocking,
+                        >,
+                        tracing_subscriber::EnvFilter,
+                        tracing_subscriber::Registry,
+                    >,
+                    tracing_appender::non_blocking::WorkerGuard,
+                )> {
+                    Err(TelemetryError::Mock)
+                }
+
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<NixPid>> {
+                    Ok(None)
+                }
+            }
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+            let result = process_watcher.start_with_helpers(&NewFuelTelemetryFailed);
+
+            assert_eq!(
+                result.err(),
+                Some(WatcherError::Fatal(TelemetryError::Mock))
+            );
+        }
+
+        #[test]
+        fn process_is_dead() {
+            setup_fuelup_home();
+
+            #[derive(Default, Clone)]
+            struct ProcessIsDead;
+
+            impl StartHelpers for ProcessIsDead {
+                fn process_is_alive(&self, _process_watcher: &ProcessWatcher) -> bool {
+                    false
+                }
+
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<NixPid>> {
+                    Ok(None)
+                }
+
+                fn exit(&self, _code: i32) -> ! {
+                    // Test we actually exited via our expected code path
+                    exit(99);
+                }
+            }
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => match waitpid(child, None).unwrap() {
+                    WaitStatus::Exited(_, code) => {
+                        assert_eq!(code, 99);
+                    }
+                    _ => panic!("Child did not exit normally"),
+                },
+                ForkResult::Child => {
+                    let mut process_watcher = ProcessWatcher::new().unwrap();
+                    let _ = process_watcher.start_with_helpers(&ProcessIsDead);
+
+                    // Incorrect status code that rusty_fork_test!() will detect
+                    exit(86);
+                }
+            }
+        }
+
+        #[test]
+        fn measure_process_called_when_ready() {
+            setup_fuelup_home();
+
+            #[derive(Default, Clone)]
+            struct MeasureProcessCalledWhenReady {
+                default_helpers: DefaultStartHelpers,
+                measure_process_called_count: Arc<AtomicI32>,
+            }
+
+            impl StartHelpers for MeasureProcessCalledWhenReady {
+                fn measure_process(&self, process_watcher: &mut ProcessWatcher) {
+                    self.measure_process_called_count
+                        .fetch_add(1, Ordering::Relaxed);
+
+                    stdout()
+                        .write_all(
+                            format!(
+                                "measure_process_called_count: {}",
+                                self.measure_process_called_count.load(Ordering::Relaxed)
+                            )
+                            .as_bytes(),
+                        )
+                        .unwrap();
+                    stdout().flush().unwrap();
+
+                    self.default_helpers.measure_process(process_watcher);
+                }
+
+                fn process_is_alive(&self, _process_watcher: &ProcessWatcher) -> bool {
+                    stdout()
+                        .write_all("process_is_alive called".as_bytes())
+                        .unwrap();
+                    stdout().flush().unwrap();
+
+                    self.measure_process_called_count.load(Ordering::Relaxed) < 2
+                }
+
+                fn get_instant_now(&self) -> Instant {
+                    stdout()
+                        .write_all("get_instant_now called".as_bytes())
+                        .unwrap();
+                    stdout().flush().unwrap();
+
+                    Instant::now()
+                }
+
+                fn measure_timer_is_ready(&self, _process_watcher: &ProcessWatcher) -> bool {
+                    stdout()
+                        .write_all("measure_timer_is_ready called".as_bytes())
+                        .unwrap();
+                    stdout().flush().unwrap();
+
+                    true
+                }
+
+                fn get_next_ready_timer<'a>(&self, timers: &[&'a Timer]) -> &'a Timer {
+                    stdout()
+                        .write_all("get_next_ready_timer called".as_bytes())
+                        .unwrap();
+                    stdout().flush().unwrap();
+
+                    timers[0]
+                }
+
+                fn sleep(&self, _duration: Duration) {
+                    stdout().write_all("sleep called".as_bytes()).unwrap();
+                    stdout().flush().unwrap();
+                }
+
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<NixPid>> {
+                    Ok(None)
+                }
+
+                fn record_metrics(&self, _process_watcher: &ProcessWatcher, _running: bool) {
+                    stdout()
+                        .write_all("record_metrics called".as_bytes())
+                        .unwrap();
+                    stdout().flush().unwrap();
+                }
+
+                fn exit(&self, _code: i32) -> ! {
+                    stdout().write_all("exit called".as_bytes()).unwrap();
+                    stdout().flush().unwrap();
+
+                    // Test we actually exited via our expected code path
+                    exit(99);
+                }
+            }
+
+            let (read_fd, write_fd) = pipe().unwrap();
+            let mut pipe_read = unsafe { File::from_raw_fd(read_fd.into_raw_fd()) };
+            let pipe_write = unsafe { File::from_raw_fd(write_fd.into_raw_fd()) };
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    drop(pipe_write);
+
+                    let mut output = String::new();
+                    pipe_read.read_to_string(&mut output).unwrap();
+
+                    assert!(output.contains("measure_process_called_count: 2"));
+                    assert!(output.contains("process_is_alive called"));
+                    assert!(output.contains("get_instant_now called"));
+                    assert!(output.contains("measure_timer_is_ready called"));
+                    assert!(output.contains("get_next_ready_timer called"));
+                    assert!(output.contains("sleep called"));
+                    assert!(output.contains("record_metrics called"));
+                    assert!(output.contains("exit called"));
+
+                    match waitpid(child, None).unwrap() {
+                        WaitStatus::Exited(_, code) => {
+                            assert_eq!(code, 99);
+                        }
+                        _ => panic!("Child did not exit normally"),
+                    }
+                }
+                ForkResult::Child => {
+                    drop(pipe_read);
+                    dup2(pipe_write.as_raw_fd(), 1).unwrap();
+
+                    let start_helpers = MeasureProcessCalledWhenReady::default();
+                    let mut process_watcher = ProcessWatcher::new().unwrap();
+                    let _ = process_watcher.start_with_helpers(&start_helpers);
+
+                    // Incorrect status code that rusty_fork_test!() will detect
+                    exit(86);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod measure_process {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use nix::{
+        sys::{
+            signal::{kill, Signal},
+            wait::{waitpid, WaitPidFlag, WaitStatus},
+        },
+        unistd::{fork, ForkResult},
+    };
+    use rusty_fork::rusty_fork_test;
+    use std::sync::Arc;
+
+    rusty_fork_test! {
+        #[test]
+        fn process_died() {
+            setup_fuelup_home();
+
+            struct ProcessDied;
+            impl StartHelpers for ProcessDied {}
+
+            let mut kill_called = false;
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    let helpers = ProcessDied;
+                    let mut process_watcher =
+                        ProcessWatcher::new_with_pid(NixPid::from_raw(child.as_raw())).unwrap();
+
+                    assert_eq!(process_watcher.resident_memory, 0);
+                    assert_eq!(process_watcher.virtual_memory, 0);
+                    assert_eq!(process_watcher.run_time, 0);
+                    assert_eq!(process_watcher.cpu_usage, 0.0);
+
+                    loop {
+                        match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+                            Ok(WaitStatus::StillAlive) => {
+                                if !kill_called {
+                                    kill(child, Signal::SIGKILL).unwrap();
+                                    kill_called = true;
+                                }
+                            }
+                            Ok(WaitStatus::Signaled(child_pid, signal, _)) => {
+                                assert_eq!(child_pid, child);
+                                assert_eq!(signal, Signal::SIGKILL);
+
+                                helpers.measure_process(&mut process_watcher);
+
+                                assert_eq!(process_watcher.resident_memory, 0);
+                                assert_eq!(process_watcher.virtual_memory, 0);
+                                assert_eq!(process_watcher.run_time, 0);
+                                assert_eq!(process_watcher.cpu_usage, 0.0);
+
+                                break;
+                            }
+                            _ => panic!("Child process terminated unexpectedly"),
+                        }
+                    }
+                }
+                ForkResult::Child => {
+                    loop {
+                        // Sleep until we're killed off
+                        sleep(Duration::from_secs(1));
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            #[derive(Default, Clone)]
+            struct AOk {
+                record_metrics_called: Arc<AtomicBool>,
+            }
+
+            impl StartHelpers for AOk {
+                fn record_metrics(&self, _process_watcher: &ProcessWatcher, _running: bool) {
+                    self.record_metrics_called.store(true, Ordering::Relaxed);
+                }
+            }
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+
+            assert_eq!(process_watcher.resident_memory, 0);
+            assert_eq!(process_watcher.virtual_memory, 0);
+            assert_eq!(process_watcher.run_time, 0);
+            assert_eq!(process_watcher.cpu_usage, 0.0);
+
+            let helpers = AOk::default();
+            helpers.measure_process(&mut process_watcher);
+
+            let at_least_one_metric_is_set = process_watcher.resident_memory > 0
+                || process_watcher.virtual_memory > 0
+                || process_watcher.run_time > 0
+                || process_watcher.cpu_usage > 0.0;
+
+            assert!(at_least_one_metric_is_set);
+
+            assert!(helpers.record_metrics_called.load(Ordering::Relaxed));
+        }
+    }
+}
+
+#[cfg(test)]
+mod process_is_alive {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use nix::{
+        sys::{
+            signal::{kill, Signal},
+            wait::{waitpid, WaitPidFlag, WaitStatus},
+        },
+        unistd::{fork, ForkResult},
+    };
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            struct AOk;
+            impl StartHelpers for AOk {}
+
+            let mut kill_called = false;
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    let helpers = AOk;
+                    let process_watcher =
+                        ProcessWatcher::new_with_pid(NixPid::from_raw(child.as_raw())).unwrap();
+
+                    assert!(helpers.process_is_alive(&process_watcher));
+
+                    loop {
+                        match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+                            Ok(WaitStatus::StillAlive) => {
+                                if !kill_called {
+                                    kill(child, Signal::SIGKILL).unwrap();
+                                    kill_called = true;
+                                }
+                            }
+                            Ok(WaitStatus::Signaled(child_pid, signal, _)) => {
+                                assert_eq!(child_pid, child);
+                                assert_eq!(signal, Signal::SIGKILL);
+                                assert!(!helpers.process_is_alive(&process_watcher));
+                                break;
+                            }
+                            _ => panic!("Child process terminated unexpectedly"),
+                        }
+                    }
+                }
+                ForkResult::Child => {
+                    loop {
+                        // Sleep until we're killed off
+                        sleep(Duration::from_secs(1));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod measure_timer_is_ready {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn not_ready() {
+            setup_fuelup_home();
+
+            struct NotReady;
+            impl StartHelpers for NotReady {}
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+
+            let measure_interval = process_watcher.measure_timer.interval;
+            process_watcher.measure_timer.last_measure = Instant::now() + (measure_interval * 2);
+
+            let helpers = NotReady;
+            assert!(!helpers.measure_timer_is_ready(&process_watcher));
+        }
+
+        #[test]
+        fn equal() {
+            setup_fuelup_home();
+
+            struct Equal;
+            impl StartHelpers for Equal {}
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+
+            let measure_interval = process_watcher.measure_timer.interval;
+            process_watcher.measure_timer.last_measure = Instant::now() - measure_interval;
+
+            let helpers = Equal;
+            assert!(helpers.measure_timer_is_ready(&process_watcher));
+        }
+
+        #[test]
+        fn late() {
+            setup_fuelup_home();
+
+            struct Late;
+            impl StartHelpers for Late {}
+
+            let mut process_watcher = ProcessWatcher::new().unwrap();
+
+            let measure_interval = process_watcher.measure_timer.interval;
+            process_watcher.measure_timer.last_measure = Instant::now() - (measure_interval * 2);
+
+            let helpers = Late;
+            assert!(helpers.measure_timer_is_ready(&process_watcher));
+        }
+    }
+}
+
+#[cfg(test)]
+mod get_next_ready_timer {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn no_timers() {
+            setup_fuelup_home();
+
+            struct NoTimers;
+            impl StartHelpers for NoTimers {}
+
+            let helpers = NoTimers;
+            let results = helpers.get_next_ready_timer(&[]);
+
+            assert_eq!(results.interval, ZERO_TIMER.interval);
+            assert_eq!(results.last_measure, ZERO_TIMER.last_measure);
+        }
+
+        #[test]
+        fn one_timer() {
+            setup_fuelup_home();
+
+            struct OneTimer;
+            impl StartHelpers for OneTimer {}
+
+            let helpers = OneTimer;
+            let timer = Timer::new(Duration::from_secs(1));
+            let results = helpers.get_next_ready_timer(&[&timer]);
+
+            assert_eq!(results.interval, timer.interval);
+            assert_eq!(results.last_measure, timer.last_measure);
+        }
+
+        #[test]
+        fn two_timers() {
+            setup_fuelup_home();
+
+            struct TwoTimers;
+            impl StartHelpers for TwoTimers {}
+
+            let helpers = TwoTimers;
+            let timer1 = Timer::new(Duration::from_secs(10));
+            let timer2 = Timer::new(Duration::from_secs(20));
+
+            let results = helpers.get_next_ready_timer(&[&timer1, &timer2]);
+            assert_eq!(results.interval, timer1.interval);
+            assert_eq!(results.last_measure, timer1.last_measure);
+
+            let results = helpers.get_next_ready_timer(&[&timer2, &timer1]);
+            assert_eq!(results.interval, timer1.interval);
+            assert_eq!(results.last_measure, timer1.last_measure);
+        }
+    }
+}
+
+#[cfg(test)]
+mod timer_new {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn zero_duration() {
+            let timer = Timer::new(Duration::from_secs(0));
+            assert_eq!(timer.interval, Duration::from_secs(0));
+            assert!(timer.last_measure <= Instant::now());
+        }
+
+        #[test]
+        fn new() {
+            let timer = Timer::new(Duration::from_secs(123));
+            assert_eq!(timer.interval, Duration::from_secs(123));
+            assert!(timer.last_measure <= Instant::now());
+        }
+    }
+}
+
+#[cfg(test)]
+mod next_ready_timer {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn no_timers() {
+            let result = Timer::next_ready_timer(&[]);
+            assert_eq!(result.interval, ZERO_TIMER.interval);
+            assert_eq!(result.last_measure, ZERO_TIMER.last_measure);
+        }
+
+        #[test]
+        fn one_timer() {
+            let timer = Timer::new(Duration::from_secs(123));
+            let result = Timer::next_ready_timer(&[&timer]);
+            assert_eq!(result.interval, timer.interval);
+            assert_eq!(result.last_measure, timer.last_measure);
+        }
+
+        #[test]
+        fn two_timers() {
+            let timer1 = Timer::new(Duration::from_secs(10));
+            let timer2 = Timer::new(Duration::from_secs(20));
+
+            let result = Timer::next_ready_timer(&[&timer1, &timer2]);
+            assert_eq!(result.interval, timer1.interval);
+            assert_eq!(result.last_measure, timer1.last_measure);
+
+            let result = Timer::next_ready_timer(&[&timer2, &timer1]);
+            assert_eq!(result.interval, timer1.interval);
+            assert_eq!(result.last_measure, timer1.last_measure);
+        }
+    }
+}
+
+#[cfg(test)]
+mod is_ready {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn not_ready() {
+            let mut timer = Timer::new(Duration::from_secs(10));
+
+            let measure_interval = timer.interval;
+            timer.last_measure = Instant::now() + (measure_interval * 2);
+
+            assert!(!timer.is_ready());
+        }
+
+        #[test]
+        fn equal() {
+            let mut timer = Timer::new(Duration::from_secs(10));
+
+            let measure_interval = timer.interval;
+            timer.last_measure = Instant::now() - measure_interval;
+
+            assert!(timer.is_ready());
+        }
+
+        #[test]
+        fn late() {
+            let mut timer = Timer::new(Duration::from_secs(10));
+
+            let measure_interval = timer.interval;
+            timer.last_measure = Instant::now() - (measure_interval * 2);
+
+            assert!(timer.is_ready());
+        }
+    }
+}
+
+#[cfg(test)]
+mod duration_until_ready {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn not_ready() {
+            let mut timer = Timer::new(Duration::from_secs(10));
+
+            let measure_interval = timer.interval;
+            timer.last_measure = Instant::now() + (measure_interval * 2);
+
+            assert_eq!(timer.duration_until_ready(), measure_interval);
+        }
+
+        #[test]
+        fn equal() {
+            let mut timer = Timer::new(Duration::from_secs(10));
+
+            let measure_interval = timer.interval;
+            timer.last_measure = Instant::now() - measure_interval;
+
+            assert_eq!(timer.duration_until_ready(), Duration::from_secs(0));
+        }
+
+        #[test]
+        fn late() {
+            let mut timer = Timer::new(Duration::from_secs(10));
+
+            let measure_interval = timer.interval;
+            timer.last_measure = Instant::now() - (measure_interval * 2);
+
+            assert_eq!(timer.duration_until_ready(), Duration::from_secs(0));
+        }
+    }
+}

--- a/src/systeminfo_watcher.rs
+++ b/src/systeminfo_watcher.rs
@@ -1,0 +1,1154 @@
+use crate::{
+    self as fuel_telemetry, daemonise, enforce_singleton, info, into_recoverable, span,
+    telemetry_config, telemetry_formatter, EnvSetting, Level, Result, TelemetryError,
+    WatcherResult,
+};
+
+use nix::{
+    fcntl::{Flock, FlockArg},
+    sys::{
+        signal::{kill, Signal::SIGKILL},
+        stat::fstat,
+    },
+    time::ClockId,
+    unistd::{getpid, Pid},
+};
+use std::{
+    env::{set_var, var},
+    fs::{File, OpenOptions},
+    io::Write,
+    os::fd::{AsRawFd, RawFd},
+    path::{Path, PathBuf},
+    process::exit,
+    sync::{
+        atomic::{AtomicBool, AtomicI32, Ordering},
+        LazyLock,
+    },
+    time::Duration,
+};
+use sysinfo::{MemoryRefreshKind, System};
+use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
+
+const PROCESS_NAME: &str = "telemetry-systeminfo-watcher";
+const TELEMETRY_PKG_NAME: &str = "systeminfo_watcher";
+
+#[derive(Debug, Clone)]
+struct SystemInfoWatcherConfig {
+    // The path to its lockfile
+    lockfile: PathBuf,
+    // The path to its logfile
+    logfile: PathBuf,
+    // The timeout for the cloud provider metadata request
+    metadata_timeout: u64,
+    // The path to its touchfile
+    touchfile: PathBuf,
+    // The number of seconds to wait between collecting metrics
+    interval: u64,
+}
+
+fn config() -> Result<&'static SystemInfoWatcherConfig> {
+    static SYSTEMINFO_WATCHER_CONFIG: LazyLock<Result<SystemInfoWatcherConfig>> =
+        LazyLock::new(|| {
+            let get_env = |key, default| EnvSetting::new(key, default).get();
+
+            Ok(SystemInfoWatcherConfig {
+                // 60*60*24*30 = 2592000 (30 days)
+                interval: get_env("SYSTEMINFO_WATCHER_INTERVAL", "2592000").parse()?,
+                metadata_timeout: get_env("METADATA_TIMEOUT", "3").parse()?,
+                lockfile: Path::new(&telemetry_config()?.fuelup_tmp)
+                    .join(format!("{}.lock", PROCESS_NAME)),
+                logfile: Path::new(&telemetry_config()?.fuelup_log)
+                    .join(format!("{}.log", PROCESS_NAME)),
+                touchfile: Path::new(&telemetry_config()?.fuelup_tmp)
+                    .join(format!("{}.touch", PROCESS_NAME)),
+            })
+        });
+
+    SYSTEMINFO_WATCHER_CONFIG
+        .as_ref()
+        .map_err(|e| TelemetryError::InvalidConfig(e.to_string()))
+}
+
+// Although there's no need to keep the state of this watcher, keep it consistent
+// with the other watchers
+
+#[derive(Default)]
+pub struct SystemInfoWatcher;
+
+// Prevent recursive calls to start()
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+/// The PID of the currently running `SystemInfoWatcher` daemon
+pub static PID: AtomicI32 = AtomicI32::new(0);
+
+impl SystemInfoWatcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn start(&mut self) -> WatcherResult<()> {
+        self.start_with_helpers(&DefaultStartHelpers)
+    }
+
+    fn start_with_helpers(&mut self, helpers: &impl StartHelpers) -> WatcherResult<()> {
+        if var("FUELUP_NO_TELEMETRY").is_ok() {
+            // If telemetry is disabled, immediately return
+            return Ok(());
+        }
+
+        let logfile = &config().map_err(into_recoverable)?.logfile;
+
+        if STARTED.load(Ordering::Relaxed) {
+            return Ok(());
+        } else {
+            STARTED.store(true, Ordering::Relaxed);
+        }
+
+        // Even though we won't be hanging around long, we still daemonise
+        // so that we don't get in the way of the calling process
+        match helpers.daemonise(logfile) {
+            Ok(Some(pid)) => {
+                // We are the parent, so record the PID then immediately return
+                PID.store(pid.as_raw(), Ordering::Relaxed);
+                return Ok(());
+            }
+            Err(e) => {
+                // Couldn't daemonise, so clear globals before returning the error
+                STARTED.store(false, Ordering::Relaxed);
+                PID.store(0, Ordering::Relaxed);
+                return Err(e);
+            }
+            Ok(None) => {
+                // We are the child process, so continue as the `SystemInfoWatcher`...
+                PID.store(getpid().as_raw(), Ordering::Relaxed);
+            }
+        }
+
+        // From here on, we are no longer the original process, so the caller should
+        // treat errors as fatal. This means that on error the process should exit
+        // immediately as there should not be two identical flows of execution
+
+        // As we record system metrics via a `TelemetryLayer`, we will need our
+        // own `tracing` `Subscriber` as the orginial `Subscriber` lives in a
+        // thread within a different process space as we've since daemonised.
+        //
+        // Warning: We need to create the `TelemetryLayer` after daemonising
+        // as there is a race condition in the thread runtime of `tracing` and
+        // the tokio runtime of `Reqwest`. Swapping order of the two could lead to
+        // possible deadlocks.
+        //
+        // Also, we need to set the bucket name as the SystemInfoWatcher is
+        // system-wide rather than being crate/process specific
+        set_var("TELEMETRY_PKG_NAME", TELEMETRY_PKG_NAME);
+        let (telemetry_layer, _guard) = helpers.new_fuel_telemetry()?;
+        tracing_subscriber::registry().with(telemetry_layer).init();
+
+        // Enforce a singleton to ensure we are the only process submitting
+        // telemetry to InfluxDB
+        let _lock = helpers.enforce_singleton(&config()?.lockfile)?;
+
+        // Check if it's time to collect metrics
+        helpers.poll_systeminfo(self)?;
+
+        helpers.exit(0)
+    }
+
+    /// Kill the `SystemInfoWatcher` daemon if one is running
+    pub fn kill() -> Result<bool> {
+        let pid = PID.load(Ordering::Relaxed);
+
+        if pid > 0 {
+            kill(Pid::from_raw(pid), SIGKILL)?;
+            PID.store(0, Ordering::Relaxed);
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn poll_systeminfo(&self) -> Result<()> {
+        self.poll_systeminfo_with_helpers(&mut DefaultPollSysteminfoHelpers)
+    }
+
+    fn poll_systeminfo_with_helpers(&self, helpers: &mut impl PollSysteminfoHelpers) -> Result<()> {
+        // If the lockfile is not found, create it and continue. Otherwise,
+        // check its modification time and return if it's too recent
+        let touchfile_lock = if !config()?.touchfile.exists() {
+            helpers.create_and_lock_touchfile(&config()?.touchfile)?
+        } else {
+            let locked_file = helpers.open_and_lock_touchfile(&config()?.touchfile)?;
+            let now = helpers.now()?;
+
+            if now.tv_sec()
+                < helpers.fstat(locked_file.as_raw_fd())?.st_mtime + config()?.interval as i64
+            {
+                // We must have collected metrics recently, so return
+                return Ok(());
+            }
+
+            locked_file
+        };
+
+        let mut sysinfo = System::new();
+        //
+        // CPU metrics
+        //
+
+        // Need to refresh twice with delay in between so that there are enough
+        // data points for "cpu_usage". See `sysinfo` docs for more details.
+        sysinfo.refresh_cpu_usage();
+        std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+        sysinfo.refresh_cpu_usage();
+
+        let cpus = sysinfo.cpus();
+        let cpu_count = cpus.len();
+        let cpu_brand = cpus
+            .first()
+            .map_or_else(String::default, |cpu| cpu.brand().into());
+
+        //
+        // Memory and OS metrics
+        //
+
+        sysinfo.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
+
+        let total_memory = sysinfo.total_memory();
+        let free_memory = sysinfo.used_memory();
+        let load_average = System::load_average();
+
+        //
+        // Build the line protocol and write to disk
+        //
+
+        #[allow(clippy::cast_precision_loss)]
+        // These values are just informational, so we can take a precision loss
+        let free_memory_percentage = (free_memory as f64) / (total_memory as f64);
+
+        // Detect if we're not running on bare metal
+        let ci = detect_ci();
+        let vm = helpers.detect_vm()?;
+
+        let span = span!(Level::INFO, "poll_systeminfo", telemetry = true);
+        let _guard = span.enter();
+
+        info!(
+            cpu_arch = System::cpu_arch(),
+            cpu_brand = cpu_brand,
+            cpu_count = cpu_count,
+            global_cpu_usage = (sysinfo.global_cpu_usage() as f64 * 100.0).trunc() / 100.0,
+            total_memory = total_memory,
+            free_memory = free_memory,
+            free_memory_percentage = (free_memory_percentage * 100.0).trunc() / 100.0,
+            os_long_name = System::long_os_version().unwrap_or_default(),
+            kernel_version = System::kernel_version().unwrap_or_default(),
+            uptime = System::uptime(),
+            vm = vm,
+            ci = ci,
+            load_average_1m = (load_average.one * 100.0).trunc() / 100.0,
+            load_average_5m = (load_average.five * 100.0).trunc() / 100.0,
+            load_average_15m = (load_average.fifteen * 100.0).trunc() / 100.0,
+        );
+
+        // Update the touchfile's modification time by truncating it
+        helpers.set_len(&touchfile_lock, 0)?;
+        helpers.sync_all(&touchfile_lock)?;
+
+        Ok(())
+    }
+
+    /// Last resort logging of errors, only to be used by the caller when there
+    /// is no other way to report an error.
+    pub fn log_error(message: &str) -> Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&config()?.logfile)?;
+
+        Ok(writeln!(file, "{}", message)?)
+    }
+}
+
+trait StartHelpers {
+    fn daemonise(&self, logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+        daemonise(logfile)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn new_fuel_telemetry(
+        &self,
+    ) -> Result<(
+        tracing_subscriber::filter::Filtered<
+            tracing_subscriber::fmt::Layer<
+                tracing_subscriber::Registry,
+                tracing_subscriber::fmt::format::DefaultFields,
+                telemetry_formatter::TelemetryFormatter,
+                tracing_appender::non_blocking::NonBlocking,
+            >,
+            tracing_subscriber::EnvFilter,
+            tracing_subscriber::Registry,
+        >,
+        tracing_appender::non_blocking::WorkerGuard,
+    )> {
+        fuel_telemetry::new!()
+    }
+
+    fn enforce_singleton(&self, lockfile_path: &Path) -> Result<Flock<File>> {
+        enforce_singleton(lockfile_path)
+    }
+
+    fn poll_systeminfo(&self, systeminfo_watcher: &SystemInfoWatcher) -> Result<()> {
+        systeminfo_watcher.poll_systeminfo()
+    }
+
+    fn exit(&self, code: i32) -> ! {
+        exit(code)
+    }
+}
+
+struct DefaultStartHelpers;
+impl StartHelpers for DefaultStartHelpers {}
+
+trait PollSysteminfoHelpers {
+    fn create_and_lock_touchfile(&self, touchfile: &Path) -> Result<Flock<File>> {
+        Ok(Flock::lock(
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(touchfile)?,
+            FlockArg::LockExclusiveNonblock,
+        )
+        .map_err(|(_, e)| e)?)
+    }
+
+    fn open_and_lock_touchfile(&self, touchfile: &Path) -> Result<Flock<File>> {
+        Ok(Flock::lock(
+            OpenOptions::new()
+                .create(false)
+                .append(true)
+                .open(touchfile)?,
+            FlockArg::LockExclusiveNonblock,
+        )
+        .map_err(|(_, e)| e)?)
+    }
+
+    fn now(&self) -> nix::Result<nix::sys::time::TimeSpec> {
+        ClockId::CLOCK_REALTIME.now()
+    }
+
+    fn fstat(&self, fd: RawFd) -> nix::Result<libc::stat> {
+        fstat(fd)
+    }
+
+    fn detect_vm(&self) -> Result<&'static str> {
+        detect_vm()
+    }
+
+    fn set_len(&self, flock: &Flock<File>, len: u64) -> std::io::Result<()> {
+        flock.set_len(len)
+    }
+
+    fn sync_all(&self, flock: &Flock<File>) -> std::io::Result<()> {
+        flock.sync_all()
+    }
+}
+
+struct DefaultPollSysteminfoHelpers;
+impl PollSysteminfoHelpers for DefaultPollSysteminfoHelpers {}
+
+fn detect_ci() -> &'static str {
+    // Check if we are running in any type of CI
+    let ci_environments = [
+        ("GITHUB_ACTIONS", "GitHub Actions"),
+        ("GITLAB_CI", "GitLab CI"),
+        ("CODEBUILD_BUILD_NUMBER", "AWS CodePipeline"),
+        ("CLOUD_RUN_JOB", "Google Cloud Build"),
+        ("TF_BUILD", "Azure Pipelines"),
+        ("CIRCLECI", "CircleCI"),
+        ("TEAMCITY_VERSION", "TeamCity"),
+        ("BITBUCKET_BUILD_NUMBER", "BitBucket Pipelines"),
+        ("TRAVIS", "Travis CI"),
+        ("JENKINS_URL", "Jenkins"),
+    ];
+
+    for (env_var, ci_name) in ci_environments {
+        if var(env_var).is_ok() {
+            return ci_name;
+        }
+    }
+    ""
+}
+
+fn detect_vm() -> Result<&'static str> {
+    // Check if we are running in a container
+    let container_environments = [
+        ("/.dockerenv", "Docker"),
+        ("/.lxc-private", "LXD"),
+        ("/.lxc", "LXD"),
+        ("/.podman-private", "Podman"),
+    ];
+
+    for (env_var, container_name) in container_environments {
+        if Path::new(env_var).exists() {
+            return Ok(container_name);
+        }
+    }
+
+    // Check if we are running in AWS Lambda
+    if var("LAMBDA_TASK_ROOT").is_ok() {
+        return Ok("AWS Lambda");
+    }
+
+    // Check for a cloud provider
+    //
+    // These are static values and are not configurable. If they change, the
+    // structure of the call may need to change as has happened in the past
+    let cloud_checks = [
+        (
+            "http://metadata.google.internal/computeMetadata/v1/instance/id",
+            vec![("Metadata-Flavor", "Google")],
+            "GCP GCE",
+        ),
+        (
+            "http://169.254.169.254/latest/api/token",
+            vec![("X-aws-ec2-metadata-token-ttl-seconds", "21600")],
+            "AWS EC2",
+        ),
+        (
+            "http://169.254.169.254/metadata/instance?api-version=2021-02-01",
+            vec![("Metadata", "true")],
+            "Azure",
+        ),
+    ];
+
+    let client = reqwest::blocking::Client::new();
+    let timeout = Duration::from_secs(config()?.metadata_timeout);
+
+    for (url, headers, provider) in cloud_checks {
+        let mut request = client.get(url).timeout(timeout);
+
+        for (key, value) in headers {
+            request = request.header(key, value);
+        }
+
+        if request.send().is_ok_and(|r| r.status().is_success()) {
+            return Ok(provider);
+        }
+    }
+
+    //  Check for a VM vendor
+    let vm_vendors = ["QEMU", "VMware", "VirtualBox", "Hyper-V", "KVM"];
+    let vendor_files = ["bios_vendor", "sys_vendor", "product_name"];
+
+    for file in vendor_files {
+        if let Ok(contents) = std::fs::read_to_string(format!("/sys/class/dmi/id/{}", file)) {
+            for vendor in vm_vendors {
+                if contents.contains(vendor) {
+                    return Ok(vendor);
+                }
+            }
+        }
+    }
+
+    Ok("")
+}
+
+#[cfg(test)]
+mod config {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use dirs::home_dir;
+    use rusty_fork::rusty_fork_test;
+    use std::env::var;
+    use std::path::Path;
+
+    rusty_fork_test! {
+        #[test]
+        fn all_unset() {
+            let config = config().unwrap();
+
+            assert_eq!(config.interval, 2592000);
+            assert_eq!(config.metadata_timeout, 3);
+
+            assert_eq!(
+                config.lockfile,
+                Path::new(
+                    &home_dir()
+                        .unwrap()
+                        .join(format!(".fuelup/tmp/{}.lock", PROCESS_NAME))
+                )
+            );
+
+            assert_eq!(
+                config.logfile,
+                Path::new(
+                    &home_dir()
+                        .unwrap()
+                        .join(format!(".fuelup/log/{}.log", PROCESS_NAME))
+                )
+            );
+
+            assert_eq!(
+                config.touchfile,
+                Path::new(
+                    &home_dir()
+                        .unwrap()
+                        .join(format!(".fuelup/tmp/{}.touch", PROCESS_NAME))
+                )
+            );
+        }
+
+        #[test]
+        fn systeminfo_watcher_interval_set() {
+            set_var("SYSTEMINFO_WATCHER_INTERVAL", "2222");
+
+            let config = config().unwrap();
+            assert_eq!(config.interval, 2222);
+        }
+
+        #[test]
+        fn systeminfo_watcher_interval_invalid() {
+            set_var("SYSTEMINFO_WATCHER_INTERVAL", "invalid interval");
+
+            assert_eq!(
+                config().err(),
+                Some(TelemetryError::InvalidConfig(
+                    TelemetryError::Parse("invalid digit found in string".to_string()).into()
+                ))
+            );
+        }
+
+        #[test]
+        fn metadata_timeout_set() {
+            set_var("METADATA_TIMEOUT", "2222");
+
+            let config = config().unwrap();
+            assert_eq!(config.metadata_timeout, 2222);
+        }
+
+        #[test]
+        fn metadata_timeout_invalid() {
+            set_var("METADATA_TIMEOUT", "invalid");
+
+            assert_eq!(
+                config().err(),
+                Some(TelemetryError::InvalidConfig(
+                    TelemetryError::Parse("invalid digit found in string".to_string()).into()
+                ))
+            );
+        }
+
+        #[test]
+        fn all_set() {
+            setup_fuelup_home();
+            let fuelup_home = var("FUELUP_HOME").unwrap();
+
+            set_var("SYSTEMINFO_WATCHER_INTERVAL", "2222");
+            set_var("METADATA_TIMEOUT", "3333");
+
+            let config = config().unwrap();
+
+            assert_eq!(config.interval, 2222);
+            assert_eq!(config.metadata_timeout, 3333);
+
+            assert_eq!(
+                config.lockfile,
+                Path::new(&format!(
+                    "{}/tmp/{}.lock",
+                    &fuelup_home, PROCESS_NAME
+                ))
+            );
+
+            assert_eq!(
+                config.logfile,
+                Path::new(&format!(
+                    "{}/log/{}.log",
+                    &fuelup_home, PROCESS_NAME
+                ))
+            );
+
+            assert_eq!(
+                config.touchfile,
+                Path::new(&format!(
+                    "{}/tmp/{}.touch",
+                    &fuelup_home, PROCESS_NAME
+                ))
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod start {
+    use super::*;
+    use crate::{into_recoverable, setup_fuelup_home, WatcherError};
+    use nix::sys::signal::kill;
+    use rusty_fork::rusty_fork_test;
+    use std::{fs::File, thread::sleep, time::Duration};
+
+    rusty_fork_test! {
+        #[test]
+        fn opted_out_is_true() {
+            setup_fuelup_home();
+
+            set_var("FUELUP_NO_TELEMETRY", "true");
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start();
+
+            // Make sure it didn't continue and init values
+            assert!(result.is_ok());
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn opted_out_is_empty() {
+            setup_fuelup_home();
+
+            // Even though it's empty, we only care if it's set
+            set_var("FUELUP_NO_TELEMETRY", "");
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start();
+
+            // Make sure it didn't continue and init values
+            assert!(result.is_ok());
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn already_started() {
+            setup_fuelup_home();
+
+            STARTED.store(true, Ordering::Relaxed);
+            PID.store(1, Ordering::Relaxed);
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start();
+
+            // Make sure it didn't continue and init values
+            assert!(result.is_ok());
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1);
+
+            // Try to start it again to test re-entrance
+            let result = systeminfo_watcher.start();
+
+            assert!(result.is_ok());
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 1);
+        }
+
+        #[test]
+        fn daemonise_failed() {
+            setup_fuelup_home();
+
+            struct DaemoniseFailed;
+
+            impl StartHelpers for DaemoniseFailed {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Err(into_recoverable(TelemetryError::Mock))
+                }
+            }
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start_with_helpers(&DaemoniseFailed);
+
+            assert_eq!(result, Err(WatcherError::Recoverable(TelemetryError::Mock)));
+            assert!(!STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 0);
+        }
+
+        #[test]
+        fn daemonise_is_parent() {
+            setup_fuelup_home();
+
+            struct DaemoniseIsParent;
+
+            impl StartHelpers for DaemoniseIsParent {
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(Some(Pid::from_raw(2222)))
+                }
+            }
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start_with_helpers(&DaemoniseIsParent);
+
+            assert_eq!(result, Ok(()));
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert_eq!(PID.load(Ordering::Relaxed), 2222);
+        }
+
+        #[test]
+        fn new_fuel_telemetry_failed() {
+            setup_fuelup_home();
+
+            struct NewFuelTelemetryFailed;
+
+            impl StartHelpers for NewFuelTelemetryFailed {
+                fn new_fuel_telemetry(
+                    &self,
+                ) -> Result<(
+                    tracing_subscriber::filter::Filtered<
+                        tracing_subscriber::fmt::Layer<
+                            tracing_subscriber::Registry,
+                            tracing_subscriber::fmt::format::DefaultFields,
+                            telemetry_formatter::TelemetryFormatter,
+                            tracing_appender::non_blocking::NonBlocking,
+                        >,
+                        tracing_subscriber::EnvFilter,
+                        tracing_subscriber::Registry,
+                    >,
+                    tracing_appender::non_blocking::WorkerGuard,
+                )> {
+                    Err(TelemetryError::Mock)
+                }
+
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+            }
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start_with_helpers(&NewFuelTelemetryFailed);
+
+            assert_eq!(result, Err(WatcherError::Fatal(TelemetryError::Mock)));
+        }
+
+        #[test]
+        fn enforce_singleton_failed() {
+            setup_fuelup_home();
+
+            struct EnforceSingletonFailed;
+
+            impl StartHelpers for EnforceSingletonFailed {
+                fn enforce_singleton(&self, _lockfile_path: &Path) -> Result<Flock<File>> {
+                    Err(TelemetryError::Mock)
+                }
+
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+            }
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start_with_helpers(&EnforceSingletonFailed);
+
+            assert_eq!(result, Err(WatcherError::Fatal(TelemetryError::Mock)));
+        }
+
+        #[test]
+        fn poll_systeminfo_failed() {
+            setup_fuelup_home();
+
+            struct PollSysteminfoFailed;
+
+            impl StartHelpers for PollSysteminfoFailed {
+                fn poll_systeminfo(&self, _systeminfo_watcher: &SystemInfoWatcher) -> Result<()> {
+                    Err(TelemetryError::Mock)
+                }
+
+                fn daemonise(&self, _logfile: &PathBuf) -> WatcherResult<Option<Pid>> {
+                    Ok(None)
+                }
+            }
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start_with_helpers(&PollSysteminfoFailed);
+
+            assert_eq!(result, Err(WatcherError::Fatal(TelemetryError::Mock)));
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            let mut systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.start();
+            let pid = PID.load(Ordering::Relaxed);
+
+            assert_eq!(result, Ok(()));
+            assert!(STARTED.load(Ordering::Relaxed));
+            assert!(pid > 0);
+
+            // SysInfoWatcher takes a few seconds to complete, so wait long
+            // enough to be run within Github Actions
+            for _ in 0..30 {
+                if kill(Pid::from_raw(pid), None).is_ok() {
+                    sleep(Duration::from_secs(1))
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod kill {
+    use super::*;
+    use nix::{
+        sys::{
+            signal::Signal,
+            wait::{waitpid, WaitPidFlag, WaitStatus},
+        },
+        unistd::{fork, ForkResult},
+    };
+    use rusty_fork::rusty_fork_test;
+    use std::thread::sleep;
+
+    rusty_fork_test! {
+        #[test]
+        fn kill_nobody() {
+            crate::systeminfo_watcher::PID.store(0, Ordering::Relaxed);
+            assert!(!SystemInfoWatcher::kill().unwrap());
+        }
+
+        #[test]
+        fn kill_systeminfo_watcher() {
+            let mut kill_called = false;
+
+            match unsafe { fork() }.unwrap() {
+                ForkResult::Parent { child } => {
+                    loop {
+                        match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+                            Ok(WaitStatus::StillAlive) => {
+                                if !kill_called {
+                                    // Since we're not daemonising, we have to set the PID manually
+                                    crate::systeminfo_watcher::PID
+                                        .store(child.as_raw(), Ordering::Relaxed);
+                                    assert!(SystemInfoWatcher::kill().unwrap());
+
+                                    kill_called = true;
+                                    continue;
+                                }
+                            }
+                            Ok(WaitStatus::Signaled(child_pid, signal, _)) => {
+                                assert_eq!(child_pid, child);
+                                assert_eq!(signal, Signal::SIGKILL);
+                                break;
+                            }
+                            _ => panic!("Child process terminated unexpectedly"),
+                        }
+                    }
+                }
+                ForkResult::Child => loop {
+                    sleep(Duration::from_secs(10));
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod poll_systeminfo {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use rusty_fork::rusty_fork_test;
+    use std::{
+        io::{BufRead, BufReader},
+        time::SystemTime,
+    };
+    use sysinfo::System;
+
+    rusty_fork_test! {
+        #[test]
+        fn create_locked_touchfile_failed() {
+            setup_fuelup_home();
+
+            struct CreateLockedTouchfileFailed;
+
+            impl PollSysteminfoHelpers for CreateLockedTouchfileFailed {
+                fn create_and_lock_touchfile(&self, _touchfile: &Path) -> Result<Flock<File>> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result =
+                systeminfo_watcher.poll_systeminfo_with_helpers(&mut CreateLockedTouchfileFailed);
+
+            assert_eq!(result, Err(TelemetryError::Mock));
+        }
+
+        #[test]
+        fn open_and_lock_touchfile_failed() {
+            setup_fuelup_home();
+
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            struct OpenAndLockTouchfileFailed;
+
+            impl PollSysteminfoHelpers for OpenAndLockTouchfileFailed {
+                fn open_and_lock_touchfile(&self, _touchfile: &Path) -> Result<Flock<File>> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result =
+                systeminfo_watcher.poll_systeminfo_with_helpers(&mut OpenAndLockTouchfileFailed);
+
+            assert_eq!(result, Err(TelemetryError::Mock));
+        }
+
+        #[test]
+        fn now_failed() {
+            setup_fuelup_home();
+
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            struct NowFailed;
+
+            impl PollSysteminfoHelpers for NowFailed {
+                fn now(&self) -> nix::Result<nix::sys::time::TimeSpec> {
+                    Err(nix::errno::Errno::EOWNERDEAD)
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.poll_systeminfo_with_helpers(&mut NowFailed);
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::Nix(
+                    nix::errno::Errno::EOWNERDEAD.to_string()
+                ))
+            );
+        }
+
+        #[test]
+        fn fstat_failed() {
+            setup_fuelup_home();
+
+            struct FstatFailed;
+
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            impl PollSysteminfoHelpers for FstatFailed {
+                fn fstat(&self, _fd: RawFd) -> nix::Result<libc::stat> {
+                    Err(nix::errno::Errno::EOWNERDEAD)
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.poll_systeminfo_with_helpers(&mut FstatFailed);
+
+            assert_eq!(
+                result,
+                Err(TelemetryError::Nix(
+                    nix::errno::Errno::EOWNERDEAD.to_string()
+                ))
+            );
+        }
+
+        #[test]
+        fn recently_polled() {
+            setup_fuelup_home();
+
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.poll_systeminfo();
+
+            assert_eq!(result, Ok(()));
+        }
+
+        #[test]
+        fn detect_vm_failed() {
+            setup_fuelup_home();
+
+            let touchfile = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            touchfile
+                .set_modified(
+                    SystemTime::now() - Duration::from_secs(config().unwrap().interval as u64),
+                )
+                .unwrap();
+
+            struct DetectVmFailed;
+
+            impl PollSysteminfoHelpers for DetectVmFailed {
+                fn detect_vm(&self) -> Result<&'static str> {
+                    Err(TelemetryError::Mock)
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.poll_systeminfo_with_helpers(&mut DetectVmFailed);
+
+            assert_eq!(result, Err(TelemetryError::Mock));
+        }
+
+        #[test]
+        fn set_len_failed() {
+            setup_fuelup_home();
+
+            let touchfile = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            touchfile
+                .set_modified(
+                    SystemTime::now() - Duration::from_secs(config().unwrap().interval as u64),
+                )
+                .unwrap();
+
+            struct SetLenFailed;
+
+            impl PollSysteminfoHelpers for SetLenFailed {
+                fn set_len(&self, _flock: &Flock<File>, _len: u64) -> std::io::Result<()> {
+                    Err(std::io::Error::new(std::io::ErrorKind::Other, "Mock error"))
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.poll_systeminfo_with_helpers(&mut SetLenFailed);
+
+            assert_eq!(result, Err(TelemetryError::IO("Mock error".to_string())));
+        }
+
+        #[test]
+        fn sync_all_failed() {
+            setup_fuelup_home();
+
+            let touchfile = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            touchfile
+                .set_modified(
+                    SystemTime::now() - Duration::from_secs(config().unwrap().interval as u64),
+                )
+                .unwrap();
+
+            struct SyncAllFailed;
+
+            impl PollSysteminfoHelpers for SyncAllFailed {
+                fn sync_all(&self, _flock: &Flock<File>) -> std::io::Result<()> {
+                    Err(std::io::Error::new(std::io::ErrorKind::Other, "Mock error"))
+                }
+            }
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+            let result = systeminfo_watcher.poll_systeminfo_with_helpers(&mut SyncAllFailed);
+
+            assert_eq!(result, Err(TelemetryError::IO("Mock error".to_string())));
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            let touchfile = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Path::new(&config().unwrap().touchfile))
+                .unwrap();
+
+            let old_modified =
+                SystemTime::now() - Duration::from_secs(config().unwrap().interval * 2);
+
+            touchfile.set_modified(old_modified).unwrap();
+
+            let systeminfo_watcher = SystemInfoWatcher::new();
+
+            // Create a telemetry layer so we the telemetry file is written to
+            set_var("TELEMETRY_PKG_NAME", "systeminfo_watcher");
+            let (telemetry_layer, _guard) = crate::new!().unwrap();
+            tracing_subscriber::registry().with(telemetry_layer).init();
+
+            let result = systeminfo_watcher.poll_systeminfo();
+            drop(_guard);
+
+            assert_eq!(result, Ok(()));
+            assert!(old_modified < touchfile.metadata().unwrap().modified().unwrap());
+
+            // Test some fields were written to the telemetry file
+
+            let telemetry_file =
+                std::fs::read_dir(Path::new(&telemetry_config().unwrap().fuelup_tmp))
+                    .unwrap()
+                    .find(|file| {
+                        file.as_ref()
+                            .unwrap()
+                            .path()
+                            .to_str()
+                            .unwrap()
+                            .contains("systeminfo_watcher.telemetry.")
+                    });
+
+            assert!(telemetry_file.is_some());
+
+            let body = {
+                let mut body = Vec::new();
+
+                let lines =
+                    BufReader::new(File::open(telemetry_file.unwrap().unwrap().path()).unwrap())
+                        .lines()
+                        .collect::<std::result::Result<Vec<_>, _>>()
+                        .unwrap();
+
+                for base64_line in lines {
+                    let decoded_line = STANDARD.decode(&base64_line).unwrap();
+                    let line = String::from_utf8(decoded_line).unwrap();
+
+                    body.push(line);
+                }
+
+                body.join("\n")
+            };
+
+            let mut sysinfo = System::new();
+
+            sysinfo.refresh_cpu_usage();
+            std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+            sysinfo.refresh_cpu_usage();
+
+            let cpus = sysinfo.cpus();
+            let cpu_brand = cpus
+                .first()
+                .map_or_else(String::default, |cpu| cpu.brand().into());
+
+            assert!(body.contains(&format!("cpu_arch=\"{}\"", System::cpu_arch())));
+            assert!(body.contains(&format!("cpu_count={}", cpus.len())));
+            assert!(body.contains(&format!("cpu_brand=\"{}\"", cpu_brand)));
+
+            assert!(body.contains(&format!(
+                "os_long_name=\"{}\"",
+                System::long_os_version().unwrap_or_default()
+            )));
+
+            assert!(body.contains(&format!(
+                "kernel_version=\"{}\"",
+                System::kernel_version().unwrap_or_default()
+            )));
+        }
+    }
+}

--- a/src/telemetry_formatter.rs
+++ b/src/telemetry_formatter.rs
@@ -1,0 +1,2435 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use chrono::Utc;
+use regex::Regex;
+use std::{env::var, path::PathBuf, sync::LazyLock};
+use sysinfo::System;
+use tracing::{Event, Subscriber};
+use tracing_subscriber::{
+    fmt::{
+        format::{FormatEvent, FormatFields, Writer},
+        FmtContext, FormattedFields,
+    },
+    registry::LookupSpan,
+};
+use uuid::Uuid;
+
+use crate::Result;
+
+/// A `tracing` `Formatter` to format telemetry to be later consumed into InfluxDB
+///
+/// This `tracing` `Formatter` adds a few extra fields to the default `tracing` `Formatter`:
+///
+/// - `triple`: the target triple of the current system
+/// - `os`: the name of the operating system
+/// - `os_version`: the version of the operating system
+/// - `crate`: the name of the crate
+/// - `version`: the version of the crate
+/// - `file`: the file where the event was generated
+///
+#[derive(Default)]
+pub struct TelemetryFormatter {
+    // Caches the system triple used for every event
+    triple: String,
+    // Caches the operating system name used for every event
+    os: String,
+    // Caches the operating system version used for every event
+    os_version: String,
+    // Trace-ID for the telemetry session
+    trace_id: String,
+}
+
+impl TelemetryFormatter {
+    /// Creates a new `TelemetryFormatter`.
+    ///
+    /// This `tracing` `Formatter` is to be used along with the `tracing` crate,
+    /// and is used to set the `Event` format.
+    ///
+    /// ```rust
+    /// use fuel_telemetry::TelemetryFormatter;
+    /// use tracing_subscriber::{fmt::Layer, Registry};
+    ///
+    /// let telemetry_formatter = TelemetryFormatter::new();
+    ///
+    /// let layer = tracing_subscriber::fmt::layer::<Registry>()
+    ///     .event_format(telemetry_formatter);
+    /// ```
+    pub fn new() -> Self {
+        let arch = match std::env::consts::ARCH {
+            arch @ ("aarch64" | "x86_64") => arch,
+            _ => "unknown",
+        };
+
+        let vendor = match std::env::consts::OS {
+            "macos" => "apple",
+            _ => "unknown",
+        };
+
+        let os = match std::env::consts::OS {
+            "macos" => "darwin",
+            "linux" => "linux-gnu",
+            _ => "unknown",
+        };
+
+        // Cache the values we'll use for every event
+        Self {
+            os: System::name().unwrap_or("unknown".to_string()),
+            os_version: System::kernel_version().unwrap_or("unknown".to_string()),
+            trace_id: Uuid::new_v4().to_string(),
+            triple: format!("{arch}-{vendor}-{os}"),
+        }
+    }
+}
+
+trait TelemetryFormatterAccessors {
+    fn triple(&self) -> &str {
+        ""
+    }
+    fn os(&self) -> &str {
+        ""
+    }
+    fn os_version(&self) -> &str {
+        ""
+    }
+    fn trace_id(&self) -> &str {
+        ""
+    }
+}
+
+impl TelemetryFormatterAccessors for TelemetryFormatter {
+    fn triple(&self) -> &str {
+        &self.triple
+    }
+
+    fn os(&self) -> &str {
+        &self.os
+    }
+
+    fn os_version(&self) -> &str {
+        &self.os_version
+    }
+
+    fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for TelemetryFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    /// Formats an `Event`.
+    ///
+    /// This function formats an `Event` into a `tracing` `Writer` with the following format:
+    ///
+    /// <timestamp> <level> <triple>:<os>:<os-version> <crate>:<version>:<file> <trace-id> <spans> <fields>
+    ///
+    /// e.g:
+    ///
+    /// ```text
+    /// 2021-08-31T14:00:00.000000Z ERROR x86_64-apple-darwin:Arch Linux:6.12.3-arch1-1 fuel-telemetry:0.1.0:fuelup/src/main.rs ddfc7485-c40f-4e3f-8203-704cccbd7475 root:span1:span2: field1="val1" "A test message"
+    /// ```
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        format_event_with_helpers(self, ctx, &mut writer, event, &DefaultFormatEventHelpers)
+    }
+}
+
+fn format_event_with_helpers<S, N>(
+    telemetry_formatter: &impl TelemetryFormatterAccessors,
+    ctx: &FmtContext<'_, S, N>,
+    writer: &mut Writer<'_>,
+    event: &Event<'_>,
+    helpers: &impl FormatEventHelpers,
+) -> std::fmt::Result
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    if !helpers.wants_telemetry(ctx) {
+        return Ok(());
+    }
+
+    // Use a temporary buffer as the writer for the event, then at the end
+    // we Base64 encode the buffer and write it to passed-in writer.
+    let mut buffer = String::new();
+    let mut tmp_writer = Writer::new(&mut buffer);
+
+    helpers.write_metadata(telemetry_formatter, &mut tmp_writer, event)?;
+    helpers.write_spans(&mut tmp_writer, ctx, event)?;
+    helpers.write_encoded_buffer(writer, &buffer)?;
+
+    Ok(())
+}
+
+trait FormatEventHelpers {
+    /// Check if the event wants telemetry enabled
+    ///
+    /// Going from leaf span to the root, we check if any of the spans have a
+    /// `telemetry` field set to `false`. If so, short-circuit return.
+    ///
+    /// If a `telemetry` field is set to `true`, we set the `wants_telemetry`
+    /// flag to `true` and then break.
+    fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+        N: for<'a> FormatFields<'a> + 'static,
+    {
+        for span in ctx.event_scope().into_iter().flatten() {
+            if let Some(fields) = span.extensions().get::<FormattedFields<N>>() {
+                // A regex to parse the `telemetry` field from the span's fields
+                static TELEMETRY_SETTING_REGEX: LazyLock<Result<Regex>> =
+                    LazyLock::new(|| Ok(regex::Regex::new(r"telemetry\s*=\s*(true|false)")?));
+
+                let telemetry_setting = TELEMETRY_SETTING_REGEX
+                    .as_ref()
+                    .ok()
+                    .and_then(|regex| regex.captures(fields.fields.as_str()))
+                    .and_then(|captures| captures.get(1))
+                    .map(|m| m.as_str());
+
+                match telemetry_setting {
+                    Some("false") => return false,
+                    Some("true") => return true,
+                    _ => continue,
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Write the event metadata to the writer
+    fn write_metadata(
+        &self,
+        telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+        writer: &mut Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        // We deliberately use fixed .9 digit precision followed by Zulu as
+        // InfluxDB seems to have a few issues with parsing timezones, offsets,
+        // and nanoseconds.
+        write!(
+            writer,
+            "{} {:>5} {}:{}:{} {}:{}:{} {} ",
+            Utc::now().format("%Y-%m-%dT%H:%M:%S%.9fZ"),
+            event.metadata().level(),
+            telemetry_formatter_accessors.triple(),
+            telemetry_formatter_accessors.os(),
+            telemetry_formatter_accessors.os_version(),
+            var("TELEMETRY_PKG_NAME").unwrap_or("unknown".to_string()),
+            var("TELEMETRY_PKG_VERSION").unwrap_or("unknown".to_string()),
+            self.sanitise_file_path(event, |path| PathBuf::from(path)),
+            telemetry_formatter_accessors.trace_id(),
+        )?;
+
+        Ok(())
+    }
+
+    /// Strip everything before and including src/ in the filepath
+    fn sanitise_file_path<F: Fn(&str) -> PathBuf>(
+        &self,
+        event: &Event<'_>,
+        pathbuf_from: F,
+    ) -> String {
+        event
+            .metadata()
+            .file()
+            .map(|path| {
+                let path = pathbuf_from(path);
+                let path = path
+                    .components()
+                    .position(|c| c.as_os_str() == "src")
+                    .map(|pos| path.components().skip(pos + 1).collect::<PathBuf>())
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .into_owned();
+
+                if path.is_empty() {
+                    "unknown".to_string()
+                } else {
+                    path
+                }
+            })
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
+    /// Expand each span and its fields to the writer
+    fn write_spans<S, N>(
+        &self,
+        writer: &mut Writer<'_>,
+        ctx: &FmtContext<'_, S, N>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+        N: for<'a> FormatFields<'a> + 'static,
+    {
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                write!(writer, "{}", span.name())?;
+
+                if let Some(fields) = span.extensions().get::<FormattedFields<N>>() {
+                    if !fields.is_empty() {
+                        // Strip the telemetry field from the outputted fields
+                        static STRIP_TELEMETRY_REGEX: LazyLock<Result<Regex>> =
+                            LazyLock::new(|| {
+                                Ok(regex::Regex::new(r"\s*telemetry\s*=\s*(true|false)\s*")?)
+                            });
+
+                        let fields = STRIP_TELEMETRY_REGEX
+                            .as_ref()
+                            .map_err(|_| std::fmt::Error)?
+                            .replace_all(fields.fields.as_str(), "")
+                            .to_string();
+
+                        if !fields.is_empty() {
+                            write!(writer, "{{{fields}}}")?;
+                        }
+                    }
+                };
+
+                write!(writer, ":")?;
+            }
+
+            write!(writer, " ")?;
+        }
+
+        // Call out to the default field formatter
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+
+        Ok(())
+    }
+
+    /// Base64 encode the buffer before writing it to the writer
+    fn write_encoded_buffer(&self, writer: &mut Writer<'_>, buffer: &str) -> std::fmt::Result {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        let encoded = STANDARD.encode(buffer);
+        writeln!(writer, "{encoded}")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Default, Clone)]
+struct DefaultFormatEventHelpers;
+impl FormatEventHelpers for DefaultFormatEventHelpers {}
+
+#[cfg(test)]
+mod new {
+    use super::*;
+    use sysinfo::System;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_new() {
+        // This test may seem like a tautology based on the definition of
+        // `new()`, but at least it will help catch regressions
+
+        let formatter = TelemetryFormatter::new();
+
+        assert_eq!(
+            formatter.os,
+            System::name().unwrap_or("unknown".to_string())
+        );
+
+        assert_eq!(
+            formatter.os_version,
+            System::kernel_version().unwrap_or("unknown".to_string())
+        );
+
+        assert!(Uuid::parse_str(&formatter.trace_id).is_ok());
+
+        let triple = format!(
+            "{}-{}-{}",
+            match std::env::consts::ARCH {
+                arch @ ("aarch64" | "x86_64") => arch,
+                _ => "unknown",
+            },
+            match std::env::consts::OS {
+                "macos" => "apple",
+                _ => "unknown",
+            },
+            match std::env::consts::OS {
+                "macos" => "darwin",
+                "linux" => "linux-gnu",
+                _ => "unknown",
+            }
+        );
+
+        assert_eq!(formatter.triple, triple);
+    }
+}
+
+// Helper macro to hide the block under #[cfg(test)] but within the same scope
+macro_rules! cfg_test {
+    ($($item:item)*) => {
+        $(
+            #[cfg(test)]
+            $item
+        )*
+    }
+}
+
+// Some of the `tracing` types generated when `Event`s are formatted have no
+// public constructors, and so calling individual helper methods of
+// `FormatEventHelpers` directly inside unit tests is impossible. As such, in
+// order to test these methods, we essentially have to create a new `Formatter`
+// type that we can then override within each unit test.
+//
+// ... unfortunately this also means we need to setup the whole `tracing`
+// infrastructure in order to get our test `Formatter` calling test methods.
+//
+// This helper macro generates as much `tracing` infrastructure as possible so
+// that each unit test can test its own `Formatter` implementations.
+cfg_test! {
+    use std::{
+        io::Write,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, Mutex, OnceLock,
+        },
+    };
+    use tracing::span;
+    use tracing_appender::non_blocking::NonBlocking;
+    use tracing_subscriber::{
+        fmt::{format::DefaultFields, Layer},
+        layer::{Context, Layer as LayerTrait},
+        prelude::__tracing_subscriber_SubscriberExt,
+        registry::Registry,
+        util::SubscriberInitExt,
+    };
+
+    #[derive(Default, Debug)]
+    struct BufferWriter {
+        buffer: Arc<Mutex<String>>,
+    }
+
+    static BUFFERED_WRITER: LazyLock<BufferWriter> = LazyLock::new(BufferWriter::default);
+
+    impl Write for BufferWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.buffer
+                .lock()
+                .unwrap()
+                .push_str(std::str::from_utf8(buf).unwrap());
+
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl std::fmt::Write for BufferWriter {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            self.buffer.lock().unwrap().push_str(s);
+            Ok(())
+        }
+    }
+
+    impl Clone for BufferWriter {
+        fn clone(&self) -> Self {
+            BufferWriter {
+                buffer: self.buffer.clone(),
+            }
+        }
+    }
+
+    macro_rules! generate_test_formatter {
+        ($name:ident) => {
+            generate_test_formatter!($name, {})
+        };
+
+        ($name:ident, { $($impl_block:tt)* }) => {
+            {
+                #[derive(Default, Clone)]
+                struct TestFormatter<H: FormatEventHelpers> {
+                    helpers: H,
+                }
+
+                impl<S, N, H: FormatEventHelpers> FormatEvent<S, N> for TestFormatter<H>
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    fn format_event(
+                        &self,
+                        ctx: &FmtContext<'_, S, N>,
+                        mut writer: Writer<'_>,
+                        event: &Event<'_>,
+                    ) -> std::fmt::Result {
+                        format_event_with_helpers(
+                            self,
+                            ctx,
+                            &mut writer,
+                            event,
+                            &self.helpers,
+                        )
+                    }
+                }
+
+                impl<H: FormatEventHelpers> TelemetryFormatterAccessors for TestFormatter<H> {
+                    $($impl_block)*
+                }
+
+                struct TestLayer<H: FormatEventHelpers> {
+                    inner: Layer<Registry, DefaultFields, TestFormatter<H>, NonBlocking>,
+                }
+
+                impl<H: FormatEventHelpers + 'static> LayerTrait<Registry> for &'static TestLayer<H> {
+                    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, Registry>) {
+                        self.inner.on_event(event, ctx);
+                    }
+
+                    fn on_enter(&self, id: &span::Id, ctx: Context<'_, Registry>) {
+                        self.inner.on_enter(id, ctx);
+                    }
+
+                    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, Registry>) {
+                        self.inner.on_new_span(attrs, id, ctx);
+                    }
+                }
+
+                let (writer, flush_guard) = tracing_appender::non_blocking(BUFFERED_WRITER.clone());
+
+                let format_event_helpers = $name::default();
+                static TEST_FORMATTER: OnceLock<TestFormatter<$name>> = OnceLock::new();
+                let _ = TEST_FORMATTER.set(TestFormatter { helpers: format_event_helpers.clone() });
+
+                let inner_layer = tracing_subscriber::fmt::layer::<Registry>()
+                    .with_writer(writer.clone())
+                    .with_ansi(false)
+                    .event_format(TEST_FORMATTER.get().unwrap().clone());
+
+                static TEST_LAYER: OnceLock<TestLayer<$name>> = OnceLock::new();
+                let _ = TEST_LAYER.set(TestLayer{ inner: inner_layer });
+
+                let default_guard = Registry::default()
+                    .with(TEST_LAYER.get().unwrap())
+                    .init();
+
+               (flush_guard, default_guard, format_event_helpers)
+            }
+        };
+    }
+}
+
+// To minimise complexity, we'll separate the testing of `format_event()` from
+// the testing of its individual helper methods i.e. the following module mostly
+// just tests that the expected code paths were taken in the event of an error,
+// whereas the testing of actual logic and output of the helper methods will be
+// done in the modules following this one.
+#[cfg(test)]
+mod format_event {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn no_telemetry() {
+            #[derive(Default, Clone)]
+            struct NoTelemetryHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                write_metadata_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for NoTelemetryHelpers {
+                fn wants_telemetry<S, N>(&self, _ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+                    false
+                }
+
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        writer,
+                        event,
+                    )
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(NoTelemetryHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "no_telemetry").in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(!format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn wants_telemetry() {
+            #[derive(Default, Clone)]
+            struct WantsTelemetryHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                write_metadata_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for WantsTelemetryHelpers {
+                fn wants_telemetry<S, N>(&self, _ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+                    true
+                }
+
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        writer,
+                        event,
+                    )
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(WantsTelemetryHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "wants_telemetry", telemetry = true)
+                    .in_scope(|| {
+                        tracing::error!("test message");
+                    });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn write_metadata_failed() {
+            #[derive(Default, Clone)]
+            struct WriteMetadataFailedHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                write_metadata_called: Arc<AtomicBool>,
+                write_spans_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for WriteMetadataFailedHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.wants_telemetry(ctx)
+                }
+
+                fn write_metadata(
+                    &self,
+                    _telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    _writer: &mut Writer<'_>,
+                    _event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+                    Err(std::fmt::Error)
+                }
+
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_spans(writer, ctx, event)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(WriteMetadataFailedHelpers);
+
+                tracing::span!(
+                    tracing::Level::ERROR,
+                    "write_metadata_failed",
+                    telemetry = true
+                )
+                .in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert!(!format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn write_spans_failed() {
+            #[derive(Default, Clone)]
+            struct WriteSpansFailedHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                write_metadata_called: Arc<AtomicBool>,
+                write_spans_called: Arc<AtomicBool>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for WriteSpansFailedHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.wants_telemetry(ctx)
+                }
+
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        writer,
+                        event,
+                    )
+                }
+
+                fn write_spans<S, N>(
+                    &self,
+                    _writer: &mut Writer<'_>,
+                    _ctx: &FmtContext<'_, S, N>,
+                    _event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+                    Err(std::fmt::Error)
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    self.default_helpers.write_encoded_buffer(writer, buffer)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(WriteSpansFailedHelpers);
+
+                tracing::span!(
+                    tracing::Level::ERROR,
+                    "write_spans_failed",
+                    telemetry = true
+                )
+                .in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+
+                assert!(!format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn write_encoded_buffer_failed() {
+            #[derive(Default, Clone)]
+            struct WriteEncodedBufferFailedHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                write_metadata_called: Arc<AtomicBool>,
+                write_spans_called: Arc<AtomicBool>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for WriteEncodedBufferFailedHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.wants_telemetry(ctx)
+                }
+
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        writer,
+                        event,
+                    )
+                }
+
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_spans(writer, ctx, event)
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    _writer: &mut Writer<'_>,
+                    _buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    Err(std::fmt::Error)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(WriteEncodedBufferFailedHelpers);
+
+                tracing::span!(
+                    tracing::Level::ERROR,
+                    "write_encoded_buffer_failed",
+                    telemetry = true
+                )
+                .in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn ok() {
+            #[derive(Default, Clone)]
+            struct OkHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                write_metadata_called: Arc<AtomicBool>,
+                write_spans_called: Arc<AtomicBool>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for OkHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.wants_telemetry(ctx)
+                }
+
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        writer,
+                        event,
+                    )
+                }
+
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_spans(writer, ctx, event)
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    self.default_helpers.write_encoded_buffer(writer, buffer)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(OkHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "ok", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            // Finally we can test that it was successfully written to!
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+    }
+}
+
+#[cfg(test)]
+mod wants_telemetry {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn no_span() {
+            #[derive(Default, Clone)]
+            struct NoSpanHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                wants_telemetry_result: Arc<OnceLock<bool>>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for NoSpanHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.wants_telemetry(ctx);
+                    self.wants_telemetry_result.set(result).unwrap();
+
+                    result
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    // Check if we made it all the way to the end of
+                    // `format_event()`, or short-circuited
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    self.default_helpers.write_encoded_buffer(writer, buffer)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(NoSpanHelpers);
+
+                tracing::event!(tracing::Level::ERROR, "test message");
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(!*format_event_helpers.wants_telemetry_result.get().unwrap());
+
+                assert!(!format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn no_telemetry_field() {
+            #[derive(Default, Clone)]
+            struct NoTelemetryFieldHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                wants_telemetry_result: Arc<OnceLock<bool>>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for NoTelemetryFieldHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.wants_telemetry(ctx);
+                    self.wants_telemetry_result.set(result).unwrap();
+
+                    result
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    // Check if we made it all the way to the end of
+                    // `format_event()`, or short-circuited
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    self.default_helpers.write_encoded_buffer(writer, buffer)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(NoTelemetryFieldHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "no_telemetry_field").in_scope(|| {
+                    tracing::span!(tracing::Level::ERROR, "no_telemetry_field_child").in_scope(|| {
+                        tracing::span!(tracing::Level::ERROR, "no_telemetry_field_grandchild").in_scope(|| {
+                            tracing::span!(tracing::Level::ERROR, "no_telemetry_field_great_grandchild").in_scope(|| {
+                                tracing::error!("test message");
+                            });
+                        });
+                    });
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(!*format_event_helpers.wants_telemetry_result.get().unwrap());
+
+                assert!(!format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn telemetry_field_false() {
+            #[derive(Default, Clone)]
+            struct TelemetryFieldFalseHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                wants_telemetry_result: Arc<OnceLock<bool>>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for TelemetryFieldFalseHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.wants_telemetry(ctx);
+                    self.wants_telemetry_result.set(result).unwrap();
+
+                    result
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    // Check if we made it all the way to the end of
+                    // `format_event()`, or short-circuited
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    self.default_helpers.write_encoded_buffer(writer, buffer)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(TelemetryFieldFalseHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "telemetry_field_false",).in_scope(|| {
+                    tracing::span!(tracing::Level::ERROR, "telemetry_field_false_child").in_scope(|| {
+                        tracing::span!(tracing::Level::ERROR, "telemetry_field_false_grandchild", telemetry = false).in_scope(|| {
+                            tracing::span!(tracing::Level::ERROR, "telemetry_field_false_great_grandchild").in_scope(|| {
+                                tracing::error!("test message");
+                            });
+                        });
+                    });
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(!*format_event_helpers.wants_telemetry_result.get().unwrap());
+
+                assert!(!format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn telemetry_field_true() {
+            #[derive(Default, Clone)]
+            struct TelemetryFieldTrueHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                wants_telemetry_called: Arc<AtomicBool>,
+                wants_telemetry_result: Arc<OnceLock<bool>>,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for TelemetryFieldTrueHelpers {
+                fn wants_telemetry<S, N>(&self, ctx: &FmtContext<'_, S, N>) -> bool
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.wants_telemetry_called.store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.wants_telemetry(ctx);
+                    self.wants_telemetry_result.set(result).unwrap();
+
+                    result
+                }
+
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    // Veryfying we made it all the way to the end of `format_event()`
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    self.default_helpers.write_encoded_buffer(writer, buffer)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(TelemetryFieldTrueHelpers, {
+                        fn triple(&self) -> &str {
+                            "TRIPLE"
+                        }
+
+                        fn os(&self) -> &str {
+                            "OS"
+                        }
+
+                        fn os_version(&self) -> &str {
+                            "OS_VERSION"
+                        }
+
+                        fn trace_id(&self) -> &str {
+                            "TRACE_ID"
+                        }
+                    });
+
+                tracing::span!(tracing::Level::ERROR, "telemetry_field_true", telemetry = true).in_scope(|| {
+                    tracing::span!(tracing::Level::ERROR, "telemetry_field_true_child").in_scope(|| {
+                        tracing::span!(tracing::Level::ERROR, "telemetry_field_true_grandchild", telemetry = true).in_scope(|| {
+                            tracing::span!(tracing::Level::ERROR, "telemetry_field_true_great_grandchild").in_scope(|| {
+                                tracing::error!("test message");
+                            });
+                        });
+                    });
+                });
+
+                assert!(format_event_helpers
+                    .wants_telemetry_called
+                    .load(Ordering::Relaxed));
+
+                assert!(*format_event_helpers.wants_telemetry_result.get().unwrap());
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .ends_with("TRACE_ID telemetry_field_true:telemetry_field_true_child:telemetry_field_true_grandchild:telemetry_field_true_great_grandchild: test message"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod write_metadata {
+    use super::*;
+    use regex::Regex;
+    use rusty_fork::rusty_fork_test;
+    use std::env::set_var;
+
+    rusty_fork_test! {
+        #[test]
+        fn write_failed() {
+            #[derive(Default)]
+            struct WriteFailedWriter;
+
+            impl std::fmt::Write for WriteFailedWriter {
+                fn write_str(&mut self, _s: &str) -> std::fmt::Result {
+                    Err(std::fmt::Error)
+                }
+            }
+
+            #[derive(Default, Clone)]
+            struct WriteFailedHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_metadata_called: Arc<AtomicBool>,
+                write_metadata_result: Arc<OnceLock<std::fmt::Result>>,
+            }
+
+            impl FormatEventHelpers for WriteFailedHelpers {
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    _writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+
+                    let mut binding = WriteFailedWriter;
+                    let mut writer = Writer::new(&mut binding);
+
+                    let result = self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        &mut writer,
+                        event,
+                    );
+
+                    self.write_metadata_result.set(result).unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(WriteFailedHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "write_failed", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert_eq!(
+                    format_event_helpers
+                        .write_metadata_result
+                        .get()
+                        .unwrap()
+                        .err(),
+                    Some(std::fmt::Error)
+                );
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn values_unset() {
+            #[derive(Default, Clone)]
+            struct VarUnsetHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_metadata_called: Arc<AtomicBool>,
+                write_metadata_result: Arc<OnceLock<std::fmt::Result>>,
+                write_metadata_buffer: Arc<OnceLock<String>>,
+            }
+
+            impl FormatEventHelpers for VarUnsetHelpers {
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+
+                    let mut buffer_writer = BufferWriter::default();
+                    let mut buffer_writer_writer = Writer::new(&mut buffer_writer);
+
+                    let result = self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        &mut buffer_writer_writer,
+                        event,
+                    );
+
+                    self.write_metadata_result.set(result).unwrap();
+
+                    self.write_metadata_buffer
+                        .set(buffer_writer.buffer.lock().unwrap().clone())
+                        .unwrap();
+
+                    writer
+                        .write_str(buffer_writer.buffer.lock().unwrap().as_str())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            let write_metadata_regex = Regex::new(
+                r"(?x)
+                \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z \s*
+                ERROR                                       \s*
+                TRIPLE:OS:OS_VERSION                        \s*
+                unknown:unknown:telemetry_formatter.rs      \s*
+                TRACE_ID                                    \s*
+            ",
+            )
+            .unwrap();
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(VarUnsetHelpers, {
+                        fn triple(&self) -> &str {
+                            "TRIPLE"
+                        }
+
+                        fn os(&self) -> &str {
+                            "OS"
+                        }
+
+                        fn os_version(&self) -> &str {
+                            "OS_VERSION"
+                        }
+
+                        fn trace_id(&self) -> &str {
+                            "TRACE_ID"
+                        }
+                    });
+
+                tracing::span!(tracing::Level::ERROR, "var_unset", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+
+                assert!(write_metadata_regex
+                    .is_match(format_event_helpers.write_metadata_buffer.get().unwrap()));
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(write_metadata_regex.is_match(
+                String::from_utf8(STANDARD.decode(buffer).unwrap())
+                    .unwrap()
+                    .as_str()
+            ));
+        }
+
+        #[test]
+        fn values_set() {
+            #[derive(Default, Clone)]
+            struct ValuesSetHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_metadata_called: Arc<AtomicBool>,
+                write_metadata_result: Arc<OnceLock<std::fmt::Result>>,
+                write_metadata_buffer: Arc<OnceLock<String>>,
+            }
+
+            impl FormatEventHelpers for ValuesSetHelpers {
+                fn write_metadata(
+                    &self,
+                    telemetry_formatter_accessors: &impl TelemetryFormatterAccessors,
+                    writer: &mut Writer<'_>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result {
+                    self.write_metadata_called.store(true, Ordering::Relaxed);
+
+                    let mut buffer_writer = BufferWriter::default();
+                    let mut buffer_writer_writer = Writer::new(&mut buffer_writer);
+
+                    let result = self.default_helpers.write_metadata(
+                        telemetry_formatter_accessors,
+                        &mut buffer_writer_writer,
+                        event,
+                    );
+
+                    self.write_metadata_result.set(result).unwrap();
+
+                    self.write_metadata_buffer
+                        .set(buffer_writer.buffer.lock().unwrap().clone())
+                        .unwrap();
+
+                    writer
+                        .write_str(buffer_writer.buffer.lock().unwrap().as_str())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            set_var("TELEMETRY_PKG_NAME", "telemetry-formatter");
+            set_var("TELEMETRY_PKG_VERSION", "0.1.0");
+
+            let write_metadata_regex = Regex::new(
+                r"(?x)
+                \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z       \s*
+                ERROR                                             \s*
+                aarch64-apple-darwin:Darwin:23.6.0                \s*
+                telemetry-formatter:0.1.0:telemetry_formatter.rs  \s*
+                \w{8}-\w{4}-\w{4}-\w{4}-\w{12}                    \s*
+            ",
+            )
+            .unwrap();
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(ValuesSetHelpers, {
+                        fn triple(&self) -> &str {
+                            "aarch64-apple-darwin"
+                        }
+
+                        fn os(&self) -> &str {
+                            "Darwin"
+                        }
+
+                        fn os_version(&self) -> &str {
+                            "23.6.0"
+                        }
+
+                        fn trace_id(&self) -> &str {
+                            static TRACE_ID: LazyLock<String> =
+                                LazyLock::new(|| Uuid::new_v4().to_string());
+                            TRACE_ID.as_str()
+                        }
+                    });
+
+                tracing::span!(tracing::Level::ERROR, "var_unset", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .write_metadata_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_metadata_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+
+                assert!(write_metadata_regex
+                    .is_match(format_event_helpers.write_metadata_buffer.get().unwrap()));
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(write_metadata_regex.is_match(
+                String::from_utf8(STANDARD.decode(buffer).unwrap())
+                    .unwrap()
+                    .as_str()
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod sanitise_file_path {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+    use std::default::Default;
+
+    rusty_fork_test! {
+        #[test]
+        fn no_path() {
+            #[derive(Default, Clone)]
+            struct NoPathHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                pathbuf_from_called: Arc<AtomicBool>,
+                sanitised_file_path_results: Arc<OnceLock<String>>,
+            }
+
+            fn pathbuf_from(no_path_helpers: &NoPathHelpers, _path: &str) -> PathBuf {
+                no_path_helpers
+                    .pathbuf_from_called
+                    .store(true, Ordering::Relaxed);
+
+                PathBuf::from("")
+            }
+
+            impl FormatEventHelpers for NoPathHelpers {
+                fn sanitise_file_path<F: Fn(&str) -> PathBuf>(
+                    &self,
+                    event: &Event<'_>,
+                    _pathbuf_from: F,
+                ) -> String {
+                    let result = self
+                        .default_helpers
+                        .sanitise_file_path(event, |path| pathbuf_from(self, path));
+
+                    self.sanitised_file_path_results
+                        .set(result.clone())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(NoPathHelpers, {
+                        fn triple(&self) -> &str {
+                            "TRIPLE"
+                        }
+
+                        fn os(&self) -> &str {
+                            "OS"
+                        }
+
+                        fn os_version(&self) -> &str {
+                            "OS_VERSION"
+                        }
+
+                        fn trace_id(&self) -> &str {
+                            "TRACE_ID"
+                        }
+                    });
+
+                tracing::span!(tracing::Level::ERROR, "no_path", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .pathbuf_from_called
+                    .load(Ordering::Relaxed));
+
+                assert_eq!(
+                    format_event_helpers
+                        .sanitised_file_path_results
+                        .get()
+                        .unwrap(),
+                    "unknown"
+                );
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .contains("TRIPLE:OS:OS_VERSION unknown:unknown:unknown TRACE_ID"));
+        }
+
+        #[test]
+        fn has_src() {
+            #[derive(Default, Clone)]
+            struct HasSrcHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                pathbuf_from_called: Arc<AtomicBool>,
+                sanitised_file_path_results: Arc<OnceLock<String>>,
+            }
+
+            fn pathbuf_from(has_src_helpers: &HasSrcHelpers, _path: &str) -> PathBuf {
+                has_src_helpers
+                    .pathbuf_from_called
+                    .store(true, Ordering::Relaxed);
+
+                PathBuf::from("/a/b/c/src/d/e/f/g")
+            }
+
+            impl FormatEventHelpers for HasSrcHelpers {
+                fn sanitise_file_path<F: Fn(&str) -> PathBuf>(
+                    &self,
+                    event: &Event<'_>,
+                    _pathbuf_from: F,
+                ) -> String {
+                    let result = self
+                        .default_helpers
+                        .sanitise_file_path(event, |path| pathbuf_from(self, path));
+
+                    self.sanitised_file_path_results
+                        .set(result.clone())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(HasSrcHelpers, {
+                        fn triple(&self) -> &str {
+                            "TRIPLE"
+                        }
+
+                        fn os(&self) -> &str {
+                            "OS"
+                        }
+
+                        fn os_version(&self) -> &str {
+                            "OS_VERSION"
+                        }
+
+                        fn trace_id(&self) -> &str {
+                            "TRACE_ID"
+                        }
+                    });
+
+                tracing::span!(tracing::Level::ERROR, "has_src", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .pathbuf_from_called
+                    .load(Ordering::Relaxed));
+
+                assert_eq!(
+                    format_event_helpers
+                        .sanitised_file_path_results
+                        .get()
+                        .unwrap(),
+                    "d/e/f/g"
+                );
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .contains("TRIPLE:OS:OS_VERSION unknown:unknown:d/e/f/g TRACE_ID"));
+        }
+
+        #[test]
+        fn no_src() {
+            #[derive(Default, Clone)]
+            struct NoSrcHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                pathbuf_from_called: Arc<AtomicBool>,
+                sanitised_file_path_results: Arc<OnceLock<String>>,
+            }
+
+            fn pathbuf_from(no_src_helpers: &NoSrcHelpers, _path: &str) -> PathBuf {
+                no_src_helpers
+                    .pathbuf_from_called
+                    .store(true, Ordering::Relaxed);
+
+                PathBuf::from("/a/b/c/d/e/f/g")
+            }
+
+            impl FormatEventHelpers for NoSrcHelpers {
+                fn sanitise_file_path<F: Fn(&str) -> PathBuf>(
+                    &self,
+                    event: &Event<'_>,
+                    _pathbuf_from: F,
+                ) -> String {
+                    let result = self
+                        .default_helpers
+                        .sanitise_file_path(event, |path| pathbuf_from(self, path));
+
+                    self.sanitised_file_path_results
+                        .set(result.clone())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(NoSrcHelpers, {
+                        fn triple(&self) -> &str {
+                            "TRIPLE"
+                        }
+
+                        fn os(&self) -> &str {
+                            "OS"
+                        }
+
+                        fn os_version(&self) -> &str {
+                            "OS_VERSION"
+                        }
+
+                        fn trace_id(&self) -> &str {
+                            "TRACE_ID"
+                        }
+                    });
+
+                tracing::span!(tracing::Level::ERROR, "no_src", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .pathbuf_from_called
+                    .load(Ordering::Relaxed));
+
+                assert_eq!(
+                    format_event_helpers
+                        .sanitised_file_path_results
+                        .get()
+                        .unwrap(),
+                    "/a/b/c/d/e/f/g"
+                );
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .contains("TRIPLE:OS:OS_VERSION unknown:unknown:/a/b/c/d/e/f/g TRACE_ID"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod write_spans {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn no_spans() {
+            #[derive(Default, Clone)]
+            struct NoSpansHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_spans_called: Arc<AtomicBool>,
+            }
+
+            impl FormatEventHelpers for NoSpansHelpers {
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+                    self.default_helpers.write_spans(writer, ctx, event)
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(NoSpansHelpers);
+
+                tracing::event!(tracing::Level::ERROR, "test message");
+
+                assert!(!format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn empty_span_names() {
+            #[derive(Default, Clone)]
+            struct EmptySpanNamesHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_spans_called: Arc<AtomicBool>,
+                write_spans_result: Arc<OnceLock<std::fmt::Result>>,
+                write_spans_buffer: Arc<OnceLock<String>>,
+            }
+
+            impl FormatEventHelpers for EmptySpanNamesHelpers {
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+
+                    let mut buffer_writer = BufferWriter::default();
+                    let mut buffer_writer_writer = Writer::new(&mut buffer_writer);
+
+                    let result =
+                        self.default_helpers
+                            .write_spans(&mut buffer_writer_writer, ctx, event);
+
+                    self.write_spans_result.set(result).unwrap();
+
+                    self.write_spans_buffer
+                        .set(buffer_writer.buffer.lock().unwrap().clone())
+                        .unwrap();
+
+                    writer
+                        .write_str(buffer_writer.buffer.lock().unwrap().as_str())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(EmptySpanNamesHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "").in_scope(|| {
+                    tracing::span!(tracing::Level::ERROR, "").in_scope(|| {
+                        tracing::span!(tracing::Level::ERROR, "", telemetry = true).in_scope(|| {
+                            tracing::span!(tracing::Level::ERROR, "").in_scope(|| {
+                                tracing::error!("test message");
+                            });
+                        });
+                    });
+                });
+
+                assert!(format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_spans_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+
+                assert_eq!(
+                    format_event_helpers.write_spans_buffer.get().unwrap(),
+                    ":::: test message"
+                );
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .ends_with(":::: test message"));
+        }
+
+        #[test]
+        fn empty_fields() {
+            #[derive(Default, Clone)]
+            struct EmptyFieldsHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_spans_called: Arc<AtomicBool>,
+                write_spans_result: Arc<OnceLock<std::fmt::Result>>,
+                write_spans_buffer: Arc<OnceLock<String>>,
+            }
+
+            impl FormatEventHelpers for EmptyFieldsHelpers {
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+
+                    let mut buffer_writer = BufferWriter::default();
+                    let mut buffer_writer_writer = Writer::new(&mut buffer_writer);
+
+                    let result =
+                        self.default_helpers
+                            .write_spans(&mut buffer_writer_writer, ctx, event);
+
+                    self.write_spans_result.set(result).unwrap();
+
+                    self.write_spans_buffer
+                        .set(buffer_writer.buffer.lock().unwrap().clone())
+                        .unwrap();
+
+                    writer
+                        .write_str(buffer_writer.buffer.lock().unwrap().as_str())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(EmptyFieldsHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "empty_fields").in_scope(|| {
+                    tracing::span!(tracing::Level::ERROR, "empty_fields_child").in_scope(|| {
+                        tracing::span!(tracing::Level::ERROR, "empty_fields_grandchild", telemetry = true).in_scope(|| {
+                            tracing::span!(tracing::Level::ERROR, "empty_fields_great_grandchild").in_scope(|| {
+                                tracing::error!("test message");
+                            });
+                        });
+                    });
+                });
+
+                assert!(format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_spans_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+
+                assert_eq!(
+                    format_event_helpers
+                        .write_spans_buffer
+                        .get()
+                        .unwrap(),
+                    "empty_fields:empty_fields_child:empty_fields_grandchild:empty_fields_great_grandchild: test message"
+                );
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .ends_with("empty_fields:empty_fields_child:empty_fields_grandchild:empty_fields_great_grandchild: test message"));
+        }
+
+        #[test]
+        fn has_fields() {
+            #[derive(Default, Clone)]
+            struct HasFieldsHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_spans_called: Arc<AtomicBool>,
+                write_spans_result: Arc<OnceLock<std::fmt::Result>>,
+                write_spans_buffer: Arc<OnceLock<String>>,
+            }
+
+            impl FormatEventHelpers for HasFieldsHelpers {
+                fn write_spans<S, N>(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    ctx: &FmtContext<'_, S, N>,
+                    event: &Event<'_>,
+                ) -> std::fmt::Result
+                where
+                    S: Subscriber + for<'a> LookupSpan<'a>,
+                    N: for<'a> FormatFields<'a> + 'static,
+                {
+                    self.write_spans_called.store(true, Ordering::Relaxed);
+
+                    let mut buffer_writer = BufferWriter::default();
+                    let mut buffer_writer_writer = Writer::new(&mut buffer_writer);
+
+                    let result =
+                        self.default_helpers
+                            .write_spans(&mut buffer_writer_writer, ctx, event);
+
+                    self.write_spans_result.set(result).unwrap();
+
+                    self.write_spans_buffer
+                        .set(buffer_writer.buffer.lock().unwrap().clone())
+                        .unwrap();
+
+                    writer
+                        .write_str(buffer_writer.buffer.lock().unwrap().as_str())
+                        .unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(HasFieldsHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "has_fields").in_scope(|| {
+                    tracing::span!(tracing::Level::ERROR, "has_fields_child", name1 = "value1").in_scope(|| {
+                        tracing::span!(tracing::Level::ERROR, "has_fields_grandchild", telemetry = true, name2 = "value2").in_scope(|| {
+                            tracing::span!(tracing::Level::ERROR, "has_fields_great_grandchild", name3 = "value3").in_scope(|| {
+                                tracing::error!("test message");
+                            });
+                        });
+                    });
+                });
+
+                assert!(format_event_helpers
+                    .write_spans_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_spans_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+
+                assert_eq!(
+                    format_event_helpers.write_spans_buffer.get().unwrap(),
+                    r#"has_fields:has_fields_child{name1="value1"}:has_fields_grandchild{name2="value2"}:has_fields_great_grandchild{name3="value3"}: test message"#
+                );
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .ends_with(r#"has_fields:has_fields_child{name1="value1"}:has_fields_grandchild{name2="value2"}:has_fields_great_grandchild{name3="value3"}: test message"#));
+        }
+    }
+}
+
+#[cfg(test)]
+mod write_encoded_buffer {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    rusty_fork_test! {
+        #[test]
+        fn write_str_failed() {
+            #[derive(Default)]
+            struct WriteFailedWriter;
+
+            impl std::fmt::Write for WriteFailedWriter {
+                fn write_str(&mut self, _s: &str) -> std::fmt::Result {
+                    Err(std::fmt::Error)
+                }
+            }
+
+            #[derive(Default, Clone)]
+            struct WriteStrFailedHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+                write_encoded_buffer_result: Arc<OnceLock<std::fmt::Result>>,
+            }
+
+            impl FormatEventHelpers for WriteStrFailedHelpers {
+                fn write_encoded_buffer(
+                    &self,
+                    _writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    let mut binding = WriteFailedWriter;
+                    let mut writer = Writer::new(&mut binding);
+
+                    let result = self
+                        .default_helpers
+                        .write_encoded_buffer(&mut writer, buffer);
+
+                    self.write_encoded_buffer_result.set(result).unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(WriteStrFailedHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "write_str_failed", telemetry = true)
+                    .in_scope(|| {
+                        tracing::error!("test message");
+                    });
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+
+                assert_eq!(
+                    format_event_helpers
+                        .write_encoded_buffer_result
+                        .get()
+                        .unwrap()
+                        .err(),
+                    Some(std::fmt::Error)
+                );
+            }
+
+            assert!(BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn empty_writer_empty_buffer() {
+            #[derive(Default, Clone)]
+            struct EmptyWriterEmptyBufferHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+                write_encoded_buffer_result: Arc<OnceLock<std::fmt::Result>>,
+            }
+
+            impl FormatEventHelpers for EmptyWriterEmptyBufferHelpers {
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.write_encoded_buffer(writer, buffer);
+                    self.write_encoded_buffer_result.set(result).unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(EmptyWriterEmptyBufferHelpers);
+
+                tracing::span!(
+                    tracing::Level::ERROR,
+                    "empty_writer_empty_buffer",
+                    telemetry = true
+                )
+                .in_scope(|| {
+                    tracing::error!("");
+                });
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .ends_with("empty_writer_empty_buffer: "));
+        }
+
+        #[test]
+        fn empty_writer() {
+            #[derive(Default, Clone)]
+            struct EmptyWriterHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+                write_encoded_buffer_result: Arc<OnceLock<std::fmt::Result>>,
+            }
+
+            impl FormatEventHelpers for EmptyWriterHelpers {
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.write_encoded_buffer(writer, buffer);
+                    self.write_encoded_buffer_result.set(result).unwrap();
+
+                    result
+                }
+            }
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(EmptyWriterHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "empty_writer", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            assert!(String::from_utf8(STANDARD.decode(buffer).unwrap())
+                .unwrap()
+                .contains("empty_writer: test message"));
+        }
+
+        #[test]
+        fn empty_buffer() {
+            #[derive(Default, Clone)]
+            struct EmptyBufferHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+                write_encoded_buffer_result: Arc<OnceLock<std::fmt::Result>>,
+            }
+
+            impl FormatEventHelpers for EmptyBufferHelpers {
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.write_encoded_buffer(writer, buffer);
+                    self.write_encoded_buffer_result.set(result).unwrap();
+
+                    result
+                }
+            }
+
+            BUFFERED_WRITER
+                .buffer
+                .lock()
+                .unwrap()
+                .push_str("ZW1wdHlfYnVmZmVy\n");
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(EmptyBufferHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "empty_buffer", telemetry = true).in_scope(|| {
+                    tracing::error!("");
+                });
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            let lines = buffer.split("\n").collect::<Vec<&str>>();
+            assert_eq!(lines.len(), 2);
+            assert_eq!(lines[0], "ZW1wdHlfYnVmZmVy");
+
+            assert!(String::from_utf8(STANDARD.decode(lines[1]).unwrap())
+                .unwrap()
+                .ends_with("empty_buffer: "));
+        }
+
+        #[test]
+        fn ok() {
+            #[derive(Default, Clone)]
+            struct OkHelpers {
+                default_helpers: DefaultFormatEventHelpers,
+                write_encoded_buffer_called: Arc<AtomicBool>,
+                write_encoded_buffer_result: Arc<OnceLock<std::fmt::Result>>,
+            }
+
+            impl FormatEventHelpers for OkHelpers {
+                fn write_encoded_buffer(
+                    &self,
+                    writer: &mut Writer<'_>,
+                    buffer: &str,
+                ) -> std::fmt::Result {
+                    self.write_encoded_buffer_called
+                        .store(true, Ordering::Relaxed);
+
+                    let result = self.default_helpers.write_encoded_buffer(writer, buffer);
+                    self.write_encoded_buffer_result.set(result).unwrap();
+
+                    result
+                }
+            }
+
+            BUFFERED_WRITER.buffer.lock().unwrap().push_str("b2s=\n");
+
+            {
+                let (_flush_guard, _default_guard, format_event_helpers) =
+                    generate_test_formatter!(OkHelpers);
+
+                tracing::span!(tracing::Level::ERROR, "ok", telemetry = true).in_scope(|| {
+                    tracing::error!("test message");
+                });
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_called
+                    .load(Ordering::Relaxed));
+
+                assert!(format_event_helpers
+                    .write_encoded_buffer_result
+                    .get()
+                    .unwrap()
+                    .is_ok());
+            }
+
+            assert!(!BUFFERED_WRITER.buffer.lock().unwrap().is_empty());
+
+            let mut buffer: String = BUFFERED_WRITER.buffer.lock().unwrap().clone();
+            buffer.pop();
+
+            let lines = buffer.split("\n").collect::<Vec<&str>>();
+            assert_eq!(lines.len(), 2);
+            assert_eq!(lines[0], "b2s=");
+
+            assert!(String::from_utf8(STANDARD.decode(lines[1]).unwrap())
+                .unwrap()
+                .contains("ok: test message"));
+        }
+    }
+}

--- a/src/telemetry_layer.rs
+++ b/src/telemetry_layer.rs
@@ -1,0 +1,268 @@
+use std::{env::var, io::Write, path::PathBuf};
+use tracing::{
+    span::{self, Id, Record},
+    Event,
+};
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_subscriber::{
+    fmt::{format::DefaultFields, Layer},
+    layer::Context,
+    Layer as LayerTrait, Registry,
+};
+
+use crate::{
+    errors::TelemetryError, telemetry_config, telemetry_formatter::TelemetryFormatter, Result,
+};
+
+/// A `tracing` `Layer` to generate telemetry to be later consumed into InfluxDB
+///
+/// This `tracing` `Layer` formats telemetry and stores the output in a known
+/// location ($FUEL_HOME/tmp/<crate>.telemetry), ready for ingestion by an
+/// InfluxDB collector.
+pub struct TelemetryLayer {
+    pub inner_layer: Layer<Registry, DefaultFields, TelemetryFormatter, NonBlocking>,
+}
+
+impl TelemetryLayer {
+    /// Although public, `__new()` is only intended to be called via the
+    /// following constructor macros:
+    ///
+    /// - `fuel_telemetry::new!()`
+    /// - `fuel_telemetry::new_with_watchers!()`
+    /// - `fuel_telemetry::new_with_watchers_and_init!()`
+    pub fn __new() -> Result<(Self, WorkerGuard)> {
+        Self::__new_with_helpers(&mut DefaultNewHelpers)
+    }
+
+    fn __new_with_helpers(helpers: &mut impl NewHelpers) -> Result<(Self, WorkerGuard)> {
+        let (writer, guard) = {
+            if var("FUELUP_NO_TELEMETRY").is_ok() {
+                // If telemetry is disabled, discards all output
+                helpers.create_non_blocking_sink()
+            } else {
+                let telemetry_pkg_name = var("TELEMETRY_PKG_NAME");
+
+                // This value needs to come from the cargo target which must be
+                // set from a macro constructor. Calling `env!('CARGO_PKG_NAME')`
+                // here will be incorrect as the macro will have already expaneded
+                // leading to the constant value "fuel-telemetry" for all targets
+                if telemetry_pkg_name.is_err() || var("TELEMETRY_PKG_VERSION").is_err() {
+                    return Err(TelemetryError::InvalidUsage);
+                }
+
+                // If telemetry is enabled, telemetry will be written to a file
+                // that is rotated hourly with the filename format:
+                // "$FUELUP_TMP/<crate>.telemetry.YYYY-MM-DD-HH"
+                helpers.create_non_blocking_appender(tracing_appender::rolling::hourly(
+                    PathBuf::from(telemetry_config()?.fuelup_tmp.clone()),
+                    format!(
+                        "{}.telemetry",
+                        telemetry_pkg_name.map_err(|_| TelemetryError::UnreadableCrateName)?
+                    ),
+                ))
+            }
+        };
+
+        // We need to disable ANSI codes as it breaks InfluxDB parsing
+        let inner_layer = tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_ansi(false)
+            .event_format(TelemetryFormatter::new());
+
+        Ok((Self { inner_layer }, guard))
+    }
+}
+
+trait NewHelpers {
+    fn create_non_blocking_sink(&mut self) -> (NonBlocking, WorkerGuard) {
+        tracing_appender::non_blocking(std::io::sink())
+    }
+
+    fn create_non_blocking_appender(
+        &mut self,
+        writer: impl Write + Send + 'static,
+    ) -> (NonBlocking, WorkerGuard) {
+        tracing_appender::non_blocking(writer)
+    }
+}
+
+struct DefaultNewHelpers;
+impl NewHelpers for DefaultNewHelpers {}
+
+// Implement the `Layer` trait for `TelemetryLayer`
+//
+// Here we simply proxy calls to the inner layer.
+impl LayerTrait<Registry> for TelemetryLayer {
+    fn on_close(&self, id: Id, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_close(id, ctx);
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_enter(id, ctx);
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_event(event, ctx);
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_exit(id, ctx);
+    }
+
+    fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_id_change(old, new, ctx);
+    }
+
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_new_span(attrs, id, ctx);
+    }
+
+    fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_follows_from(span, follows, ctx);
+    }
+
+    fn on_record(&self, span: &Id, values: &Record<'_>, ctx: Context<'_, Registry>) {
+        self.inner_layer.on_record(span, values, ctx);
+    }
+}
+
+#[cfg(test)]
+mod __new {
+    use super::*;
+    use crate::setup_fuelup_home;
+    use rusty_fork::rusty_fork_test;
+    use std::env::{remove_var, set_var};
+
+    rusty_fork_test! {
+        #[test]
+        fn opt_out_is_true() {
+            setup_fuelup_home();
+
+            set_var("FUELUP_NO_TELEMETRY", "true");
+
+            #[derive(Default)]
+            struct OptOutHelpers {
+                create_non_blocking_sink_called: bool,
+                create_non_blocking_appender_called: bool,
+            }
+
+            impl NewHelpers for OptOutHelpers {
+                fn create_non_blocking_sink(&mut self) -> (NonBlocking, WorkerGuard) {
+                    self.create_non_blocking_sink_called = true;
+                    tracing_appender::non_blocking(std::io::sink())
+                }
+
+                fn create_non_blocking_appender(
+                    &mut self,
+                    writer: impl Write + Send + 'static,
+                ) -> (NonBlocking, WorkerGuard) {
+                    self.create_non_blocking_appender_called = true;
+                    tracing_appender::non_blocking(writer)
+                }
+            }
+
+            let mut helpers = OptOutHelpers::default();
+            let result = TelemetryLayer::__new_with_helpers(&mut helpers);
+
+            assert!(result.is_ok());
+            assert!(helpers.create_non_blocking_sink_called);
+            assert!(!helpers.create_non_blocking_appender_called);
+        }
+
+        #[test]
+        fn opt_out_is_empty() {
+            setup_fuelup_home();
+
+            // Even though it's empty, we only care if it's set
+            set_var("FUELUP_NO_TELEMETRY", "");
+
+            #[derive(Default)]
+            struct OptOutHelpers {
+                create_non_blocking_sink_called: bool,
+                create_non_blocking_appender_called: bool,
+            }
+
+            impl NewHelpers for OptOutHelpers {
+                fn create_non_blocking_sink(&mut self) -> (NonBlocking, WorkerGuard) {
+                    self.create_non_blocking_sink_called = true;
+                    tracing_appender::non_blocking(std::io::sink())
+                }
+
+                fn create_non_blocking_appender(
+                    &mut self,
+                    writer: impl Write + Send + 'static,
+                ) -> (NonBlocking, WorkerGuard) {
+                    self.create_non_blocking_appender_called = true;
+                    tracing_appender::non_blocking(writer)
+                }
+            }
+
+            let mut helpers = OptOutHelpers::default();
+            let result = TelemetryLayer::__new_with_helpers(&mut helpers);
+
+            assert!(result.is_ok());
+            assert!(helpers.create_non_blocking_sink_called);
+            assert!(!helpers.create_non_blocking_appender_called);
+        }
+
+        #[test]
+        fn telemetry_pkg_name_is_not_set() {
+            setup_fuelup_home();
+
+            remove_var("TELEMETRY_PKG_NAME");
+            set_var("TELEMETRY_PKG_VERSION", "1.0.0");
+
+            let result = TelemetryLayer::__new();
+
+            assert_eq!(result.err(), Some(TelemetryError::InvalidUsage));
+        }
+
+        #[test]
+        fn telemetry_pkg_version_is_not_set() {
+            setup_fuelup_home();
+
+            remove_var("TELEMETRY_PKG_VERSION");
+            set_var("TELEMETRY_PKG_NAME", "test_pkg_name");
+
+            let result = TelemetryLayer::__new();
+
+            assert_eq!(result.err(), Some(TelemetryError::InvalidUsage));
+        }
+
+        #[test]
+        fn ok() {
+            setup_fuelup_home();
+
+            set_var("TELEMETRY_PKG_NAME", "test_pkg_name");
+            set_var("TELEMETRY_PKG_VERSION", "1.0.0");
+
+            #[derive(Default)]
+            struct OkHelpers {
+                create_non_blocking_sink_called: bool,
+                create_non_blocking_appender_called: bool,
+            }
+
+            impl NewHelpers for OkHelpers {
+                fn create_non_blocking_sink(&mut self) -> (NonBlocking, WorkerGuard) {
+                    self.create_non_blocking_sink_called = true;
+                    tracing_appender::non_blocking(std::io::sink())
+                }
+
+                fn create_non_blocking_appender(
+                    &mut self,
+                    writer: impl Write + Send + 'static,
+                ) -> (NonBlocking, WorkerGuard) {
+                    self.create_non_blocking_appender_called = true;
+                    tracing_appender::non_blocking(writer)
+                }
+            }
+
+            let mut helpers = OkHelpers::default();
+            let result = TelemetryLayer::__new_with_helpers(&mut helpers);
+
+            assert!(result.is_ok());
+            assert!(!helpers.create_non_blocking_sink_called);
+            assert!(helpers.create_non_blocking_appender_called);
+        }
+    }
+}


### PR DESCRIPTION
This PR carries over all the rewrite commits from forc-telemetry, and changes the repo name to fuel-telemetry. Basically carried Alfie's work on #1 to here, to pass CLA step.