### PR TITLE
fix: ci should run on pushes to main not master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
Realized #4 is trying to run things if they are pushed to master, which is normally what we use in FuelLabs repos. But this repo is using main as the default branch. So this PR fixes that.