### PR TITLE
feat: use same `TRACE_ID` for all watchers

### DIFF
--- a/fuel-telemetry-macros/src/lib.rs
+++ b/fuel-telemetry-macros/src/lib.rs
@@ -41,6 +41,10 @@ fn start_watchers() -> proc_macro2::TokenStream {
         // only exit on `Fatal` errors, meaning that we have since forked and
         // have become a child process so can safely fatally exit
 
+        // Set global `TRACE_ID` for all watchers (`ProcessWatcher`,
+        // `FileWatcher` and `SytemInfoWatcher`).
+        fuel_telemetry::telemetry_layer::set_trace_id_env_to_new_uuid();
+
         // Start the `ProcessWatcher`
         match fuel_telemetry::process_watcher::ProcessWatcher::new() {
             Ok(mut process_watcher) => {

--- a/src/telemetry_formatter.rs
+++ b/src/telemetry_formatter.rs
@@ -70,11 +70,15 @@ impl TelemetryFormatter {
             _ => "unknown",
         };
 
+        // This is already set by the macro that initialize watchers, so we
+        // should be getting something from env variable.
+        let trace_id = var("TRACE_ID").unwrap_or_else(|_| Uuid::new_v4().to_string());
+
         // Cache the values we'll use for every event
         Self {
             os: System::name().unwrap_or("unknown".to_string()),
             os_version: System::kernel_version().unwrap_or("unknown".to_string()),
-            trace_id: Uuid::new_v4().to_string(),
+            trace_id,
             triple: format!("{arch}-{vendor}-{os}"),
         }
     }

--- a/src/telemetry_layer.rs
+++ b/src/telemetry_layer.rs
@@ -73,6 +73,12 @@ impl TelemetryLayer {
     }
 }
 
+/// Sets `TRACE_ID` env variable to a new UUID.
+pub fn set_trace_id_env_to_new_uuid() {
+    let trace_id = uuid::Uuid::new_v4().to_string();
+    std::env::set_var("TRACE_ID", trace_id);
+}
+
 trait NewHelpers {
     fn create_non_blocking_sink(&mut self) -> (NonBlocking, WorkerGuard) {
         tracing_appender::non_blocking(std::io::sink())


### PR DESCRIPTION
Set's the `TRACE_ID` to a env variable at startup to ensure all three watchers are logging things with the same `TRACE_ID` so that we can associate things with each other while looking at the data.

<img width="1446" alt="image" src="https://github.com/user-attachments/assets/9702e01b-1544-4e5d-872e-00583ebd14ab" />

As it can be seen from the ss from influxdb local dashboard we now collect them under same trace id and then  we can differentiate them based on the measurement.